### PR TITLE
Fix/materialized view

### DIFF
--- a/components/server/.env
+++ b/components/server/.env
@@ -39,3 +39,7 @@ REPLY_SECRET=ThisIsASecretToken
 REFRESH_INTERVAL=15000 # Milliseconds
 
 # Info Server ?
+
+# Retry get_object request config
+MAX_RETRIES=10
+RETRY_TIMEOUT=2 # Milliseconds

--- a/components/server/.env
+++ b/components/server/.env
@@ -40,6 +40,6 @@ REFRESH_INTERVAL=15000 # Milliseconds
 
 # Info Server ?
 
-# Retry get_object request config
-MAX_RETRIES=10
-RETRY_TIMEOUT=2 # Milliseconds
+# Optional: retry get_object request config
+# MAX_RETRIES=10
+# RETRY_TIMEOUT=2 # Milliseconds

--- a/components/server/.env
+++ b/components/server/.env
@@ -40,6 +40,6 @@ REFRESH_INTERVAL=15000 # Milliseconds
 
 # Info Server ?
 
-# Optional: retry get_object request config
-# MAX_RETRIES=10
-# RETRY_TIMEOUT=2 # Milliseconds
+# Optional: Retry config (currently only implemented for get_object functionality)
+MAX_RETRIES=10
+RETRY_TIMEOUT=2 # Milliseconds. Doubles with each re-try.

--- a/components/server/src/database/dsls/object_dsl.rs
+++ b/components/server/src/database/dsls/object_dsl.rs
@@ -170,7 +170,7 @@ impl CrudDb for Object {
         let prepared = client.prepare(query).await?;
         let mut backoff_counter: u64 = 0;
 
-        while backoff_counter <= MAX_RETRIES {
+        while backoff_counter <= *MAX_RETRIES {
             match client
                 .query_opt(&prepared, &[&id])
                 .await {
@@ -181,7 +181,7 @@ impl CrudDb for Object {
                             // => 40001 Error from yugabyte matches to 25P02
                             "25P02" => {
                                 backoff_counter += 1;
-                                tokio::time::sleep(Duration::from_millis(RETRY_TIMEOUT ^ backoff_counter)).await;
+                                tokio::time::sleep(Duration::from_millis(*RETRY_TIMEOUT ^ backoff_counter)).await;
                             },
                             code@ _ => {
                                 return Err(anyhow!(err));}
@@ -560,7 +560,7 @@ impl Object {
         GROUP BY o.id;";
         let prepared = client.prepare(query).await?;
         let mut backoff_counter = 0;
-        while backoff_counter <= MAX_RETRIES {
+        while backoff_counter <= *MAX_RETRIES {
             match client.query_one(&prepared, &[&id]).await {
                 Ok(query) => return
                     Ok(ObjectWithRelations::from_row(&query))
@@ -570,7 +570,7 @@ impl Object {
                         match sql_error.code() {
                             "25P02" => {
                                 backoff_counter += 1;
-                                tokio::time::sleep(Duration::from_millis(RETRY_TIMEOUT ^ backoff_counter)).await;
+                                tokio::time::sleep(Duration::from_millis(*RETRY_TIMEOUT ^ backoff_counter)).await;
                             },
                             code@ _ => {
                                 return Err(anyhow!(err));}
@@ -612,7 +612,7 @@ impl Object {
         let prepared = client.prepare(&query).await?;
 
         let mut backoff_counter = 0;
-        while backoff_counter <= MAX_RETRIES {
+        while backoff_counter <= *MAX_RETRIES {
             match client
                 .query(&prepared, &inserts)
                 .await {
@@ -624,7 +624,7 @@ impl Object {
                         match sql_error.code() {
                             "25P02" => {
                                 backoff_counter += 1;
-                                tokio::time::sleep(Duration::from_millis(RETRY_TIMEOUT ^ backoff_counter)).await;
+                                tokio::time::sleep(Duration::from_millis(*RETRY_TIMEOUT ^ backoff_counter)).await;
                             },
                             code@ _ => {
                                 return Err(anyhow!(err));}

--- a/components/server/src/database/dsls/object_dsl.rs
+++ b/components/server/src/database/dsls/object_dsl.rs
@@ -183,7 +183,7 @@ impl CrudDb for Object {
                                 backoff_counter += 1;
                                 tokio::time::sleep(Duration::from_millis(*RETRY_TIMEOUT ^ backoff_counter)).await;
                             },
-                            code@ _ => {
+                            _code => {
                                 return Err(anyhow!(err));}
                         }
                     } else {
@@ -572,7 +572,7 @@ impl Object {
                                 backoff_counter += 1;
                                 tokio::time::sleep(Duration::from_millis(*RETRY_TIMEOUT ^ backoff_counter)).await;
                             },
-                            code@ _ => {
+                            _code => {
                                 return Err(anyhow!(err));}
                         }
                     } else {
@@ -626,7 +626,7 @@ impl Object {
                                 backoff_counter += 1;
                                 tokio::time::sleep(Duration::from_millis(*RETRY_TIMEOUT ^ backoff_counter)).await;
                             },
-                            code@ _ => {
+                            _code => {
                                 return Err(anyhow!(err));}
                         }
                     } else {

--- a/components/server/src/grpc/service_account.rs
+++ b/components/server/src/grpc/service_account.rs
@@ -389,7 +389,6 @@ impl ServiceAccountService for ServiceAccountServiceImpl {
         };
         return_with_log!(response);
     }
-    // !!!!! TODO!!!!!
     async fn add_pubkey_svc_account(
         &self,
         request: Request<AddPubkeySvcAccountRequest>,


### PR DESCRIPTION
Implements a retry logic for `get_object` database queries. This is a [fix](https://docs.yugabyte.com/preview/troubleshoot/nodes/trouble-common/#catalog-version-mismatch-a-ddl-occurred-while-processing-this-query) proposed by yugabyte for catalog mismatch errors.
The error occurs when a transaction completes, the materialized view is updated and then `get_object` queries are called.