### PR TITLE
fix: Fixed added relations for create requests

### DIFF
--- a/components/server/src/grpc/relations.rs
+++ b/components/server/src/grpc/relations.rs
@@ -42,7 +42,7 @@ impl RelationsService for RelationsServiceImpl {
 
         let (resource, labels_info) = tonic_invalid!(
             self.database_handler
-                .get_resource(request, self.cache.clone())
+                .get_resource(request)
                 .await,
             "Request not valid"
         );

--- a/components/server/src/grpc/relations.rs
+++ b/components/server/src/grpc/relations.rs
@@ -41,9 +41,7 @@ impl RelationsService for RelationsServiceImpl {
         let request = ModifyRelations(request.into_inner());
 
         let (resource, labels_info) = tonic_invalid!(
-            self.database_handler
-                .get_resource(request)
-                .await,
+            self.database_handler.get_resource(request).await,
             "Request not valid"
         );
         tonic_auth!(

--- a/components/server/src/hooks/hook_handler.rs
+++ b/components/server/src/hooks/hook_handler.rs
@@ -144,10 +144,8 @@ impl HookHandler {
                                 remove_relations: vec![],
                             },
                         );
-                        let (resource, labels_info) = self
-                            .database_handler
-                            .get_resource(request)
-                            .await?;
+                        let (resource, labels_info) =
+                            self.database_handler.get_resource(request).await?;
                         if let Err(e) = self
                             .database_handler
                             .modify_relations(

--- a/components/server/src/hooks/hook_handler.rs
+++ b/components/server/src/hooks/hook_handler.rs
@@ -146,7 +146,7 @@ impl HookHandler {
                         );
                         let (resource, labels_info) = self
                             .database_handler
-                            .get_resource(request, self.database_handler.cache.clone())
+                            .get_resource(request)
                             .await?;
                         if let Err(e) = self
                             .database_handler

--- a/components/server/src/middlelayer/create_db_handler.rs
+++ b/components/server/src/middlelayer/create_db_handler.rs
@@ -14,7 +14,6 @@ use aruna_rust_api::api::notification::services::v2::EventVariant;
 use dashmap::DashMap;
 use diesel_ulid::DieselUlid;
 use itertools::Itertools;
-use postgres_types::Json;
 use tokio_postgres::Client;
 
 impl DatabaseHandler {
@@ -61,7 +60,7 @@ impl DatabaseHandler {
         object.create(transaction_client).await?;
 
         // Create internal relation for parent and add user permissions for resource
-        let (parent, internal_relation): (
+        let (parent, _internal_relation): (
             Option<ObjectWithRelations>,
             DashMap<DieselUlid, InternalRelation, RandomState>,
         ) = match request.get_type() {
@@ -153,13 +152,7 @@ impl DatabaseHandler {
         }
 
         // Create DTO which combines the object and its internal relations
-        let owr = ObjectWithRelations {
-            object: object.clone(),
-            inbound: Json(DashMap::default()),
-            inbound_belongs_to: Json(internal_relation.clone()),
-            outbound: Json(DashMap::default()),
-            outbound_belongs_to: Json(DashMap::default()),
-        };
+        let owr = Object::get_object_with_relations(&object.id, &client).await?;
 
         // Update cache
         self.cache.add_object(owr.clone());

--- a/components/server/src/middlelayer/create_db_handler.rs
+++ b/components/server/src/middlelayer/create_db_handler.rs
@@ -326,7 +326,7 @@ impl DatabaseHandler {
         transaction_client: &Client,
     ) -> Result<Vec<DieselUlid>> {
         // Create specified relations
-        let internal_relations = request.get_internal_relations(object.id, self.cache.clone())?;
+        let internal_relations = request.get_internal_relations(object.id, transaction_client).await?;
         InternalRelation::batch_create(&internal_relations, transaction_client).await?;
         // Collect affected objects
         let mut affected: Vec<DieselUlid> = Vec::new();

--- a/components/server/src/middlelayer/create_db_handler.rs
+++ b/components/server/src/middlelayer/create_db_handler.rs
@@ -326,7 +326,9 @@ impl DatabaseHandler {
         transaction_client: &Client,
     ) -> Result<Vec<DieselUlid>> {
         // Create specified relations
-        let internal_relations = request.get_internal_relations(object.id, transaction_client).await?;
+        let internal_relations = request
+            .get_internal_relations(object.id, transaction_client)
+            .await?;
         InternalRelation::batch_create(&internal_relations, transaction_client).await?;
         // Collect affected objects
         let mut affected: Vec<DieselUlid> = Vec::new();

--- a/components/server/src/middlelayer/create_request_types.rs
+++ b/components/server/src/middlelayer/create_request_types.rs
@@ -153,48 +153,32 @@ impl CreateRequest {
         match self {
             CreateRequest::Project(req, _) => {
                 let mut relations = Vec::new();
-                for ir in  req
-                     .relations
-                     .iter()
-                     .filter_map(filter_relations) {
-                    
+                for ir in req.relations.iter().filter_map(filter_relations) {
                     relations.push(InternalRelation::from_api(ir, id, transaction_client).await?)
                 }
                 Ok(relations)
-            },
+            }
             CreateRequest::Collection(req) => {
                 let mut relations = Vec::new();
-                for ir in  req
-                     .relations
-                     .iter()
-                     .filter_map(filter_relations) {
-                    
+                for ir in req.relations.iter().filter_map(filter_relations) {
                     relations.push(InternalRelation::from_api(ir, id, transaction_client).await?)
                 }
                 Ok(relations)
-            },
+            }
             CreateRequest::Dataset(req) => {
                 let mut relations = Vec::new();
-                for ir in  req
-                     .relations
-                     .iter()
-                     .filter_map(filter_relations) {
-                    
+                for ir in req.relations.iter().filter_map(filter_relations) {
                     relations.push(InternalRelation::from_api(ir, id, transaction_client).await?)
                 }
                 Ok(relations)
-            },
+            }
             CreateRequest::Object(req) => {
                 let mut relations = Vec::new();
-                for ir in  req
-                     .relations
-                     .iter()
-                     .filter_map(filter_relations) {
-                    
+                for ir in req.relations.iter().filter_map(filter_relations) {
                     relations.push(InternalRelation::from_api(ir, id, transaction_client).await?)
                 }
                 Ok(relations)
-            },
+            }
         }
     }
     pub fn get_external_relations(&self) -> Vec<ExternalRelation> {

--- a/components/server/src/middlelayer/create_request_types.rs
+++ b/components/server/src/middlelayer/create_request_types.rs
@@ -145,36 +145,56 @@ impl CreateRequest {
         Ok(container.0)
     }
 
-    pub fn get_internal_relations(
+    pub async fn get_internal_relations(
         &self,
         id: DieselUlid,
-        cache: Arc<Cache>,
+        transaction_client: &Client,
     ) -> Result<Vec<InternalRelation>> {
         match self {
-            CreateRequest::Project(req, _) => req
-                .relations
-                .iter()
-                .filter_map(filter_relations)
-                .map(|ir| InternalRelation::from_api(ir, id, cache.clone()))
-                .collect::<Result<Vec<InternalRelation>>>(),
-            CreateRequest::Collection(req) => req
-                .relations
-                .iter()
-                .filter_map(filter_relations)
-                .map(|ir| InternalRelation::from_api(ir, id, cache.clone()))
-                .collect::<Result<Vec<InternalRelation>>>(),
-            CreateRequest::Dataset(req) => req
-                .relations
-                .iter()
-                .filter_map(filter_relations)
-                .map(|ir| InternalRelation::from_api(ir, id, cache.clone()))
-                .collect::<Result<Vec<InternalRelation>>>(),
-            CreateRequest::Object(req) => req
-                .relations
-                .iter()
-                .filter_map(filter_relations)
-                .map(|ir| InternalRelation::from_api(ir, id, cache.clone()))
-                .collect::<Result<Vec<InternalRelation>>>(),
+            CreateRequest::Project(req, _) => {
+                let mut relations = Vec::new();
+                for ir in  req
+                     .relations
+                     .iter()
+                     .filter_map(filter_relations) {
+                    
+                    relations.push(InternalRelation::from_api(ir, id, transaction_client).await?)
+                }
+                Ok(relations)
+            },
+            CreateRequest::Collection(req) => {
+                let mut relations = Vec::new();
+                for ir in  req
+                     .relations
+                     .iter()
+                     .filter_map(filter_relations) {
+                    
+                    relations.push(InternalRelation::from_api(ir, id, transaction_client).await?)
+                }
+                Ok(relations)
+            },
+            CreateRequest::Dataset(req) => {
+                let mut relations = Vec::new();
+                for ir in  req
+                     .relations
+                     .iter()
+                     .filter_map(filter_relations) {
+                    
+                    relations.push(InternalRelation::from_api(ir, id, transaction_client).await?)
+                }
+                Ok(relations)
+            },
+            CreateRequest::Object(req) => {
+                let mut relations = Vec::new();
+                for ir in  req
+                     .relations
+                     .iter()
+                     .filter_map(filter_relations) {
+                    
+                    relations.push(InternalRelation::from_api(ir, id, transaction_client).await?)
+                }
+                Ok(relations)
+            },
         }
     }
     pub fn get_external_relations(&self) -> Vec<ExternalRelation> {

--- a/components/server/src/middlelayer/relations_db_handler.rs
+++ b/components/server/src/middlelayer/relations_db_handler.rs
@@ -1,4 +1,3 @@
-use crate::caching::cache::Cache;
 use crate::database::dsls::internal_relation_dsl::{
     InternalRelation, INTERNAL_RELATION_VARIANT_BELONGS_TO, INTERNAL_RELATION_VARIANT_VERSION,
 };
@@ -12,7 +11,6 @@ use ahash::HashSet;
 use anyhow::{anyhow, Result};
 use aruna_rust_api::api::notification::services::v2::EventVariant;
 use diesel_ulid::DieselUlid;
-use std::sync::Arc;
 
 impl DatabaseHandler {
     pub async fn modify_relations(
@@ -136,14 +134,13 @@ impl DatabaseHandler {
     pub async fn get_resource(
         &self,
         request: ModifyRelations,
-        cache: Arc<Cache>,
     ) -> Result<(Object, RelationsToModify)> {
         let client = self.database.get_client().await?;
         let id = request.get_id()?;
         let resource = Object::get_object_with_relations(&id, &client).await?;
         Ok((
             resource.object.clone(),
-            request.get_relations(resource, cache)?,
+            request.get_relations(resource, &client).await?, // Client instead of transaction client is okay here, because only get requests are made before modifications
         ))
     }
 }

--- a/components/server/src/middlelayer/relations_request_types.rs
+++ b/components/server/src/middlelayer/relations_request_types.rs
@@ -49,9 +49,19 @@ impl ModifyRelations {
         )];
 
         let (external_add_relations, internal_add_relations, mut added_to_check) =
-            ModifyRelations::convert_relations(&self.0.add_relations, resource_id, transaction_client).await?;
+            ModifyRelations::convert_relations(
+                &self.0.add_relations,
+                resource_id,
+                transaction_client,
+            )
+            .await?;
         let (external_rm_relations, temp_rm_int_relations, mut removed_to_check) =
-            ModifyRelations::convert_relations(&self.0.remove_relations, resource_id, transaction_client).await?;
+            ModifyRelations::convert_relations(
+                &self.0.remove_relations,
+                resource_id,
+                transaction_client,
+            )
+            .await?;
         if !temp_rm_int_relations
             .iter()
             .filter(|ir| ir.relation_name == INTERNAL_RELATION_VARIANT_VERSION)
@@ -109,11 +119,14 @@ impl ModifyRelations {
                         ));
                         internal_relations
                             // Try into generates a new ULID, so rm via ID does not work
-                            .push(InternalRelation::from_api(
-                                internal,
-                                resource_id,
-                                transaction_client,
-                            ).await?);
+                            .push(
+                                InternalRelation::from_api(
+                                    internal,
+                                    resource_id,
+                                    transaction_client,
+                                )
+                                .await?,
+                            );
                     }
                 }
             }

--- a/components/server/src/middlelayer/relations_request_types.rs
+++ b/components/server/src/middlelayer/relations_request_types.rs
@@ -1,5 +1,4 @@
 use crate::auth::structs::Context;
-use crate::caching::cache::Cache;
 use crate::database::dsls::internal_relation_dsl::{
     InternalRelation, INTERNAL_RELATION_VARIANT_VERSION,
 };
@@ -10,7 +9,7 @@ use aruna_rust_api::api::storage::models::v2::{relation, Relation};
 use aruna_rust_api::api::storage::services::v2::ModifyRelationsRequest;
 use diesel_ulid::DieselUlid;
 use std::str::FromStr;
-use std::sync::Arc;
+use tokio_postgres::Client;
 
 pub struct ModifyRelations(pub ModifyRelationsRequest);
 
@@ -36,10 +35,10 @@ impl ModifyRelations {
     pub fn get_id(&self) -> Result<DieselUlid> {
         Ok(DieselUlid::from_str(&self.0.resource_id)?)
     }
-    pub fn get_relations(
+    pub async fn get_relations(
         &self,
         resource: ObjectWithRelations,
-        cache: Arc<Cache>,
+        transaction_client: &Client,
     ) -> Result<RelationsToModify> {
         let resource_id = resource.object.id;
 
@@ -50,9 +49,9 @@ impl ModifyRelations {
         )];
 
         let (external_add_relations, internal_add_relations, mut added_to_check) =
-            ModifyRelations::convert_relations(&self.0.add_relations, resource_id, cache.clone())?;
+            ModifyRelations::convert_relations(&self.0.add_relations, resource_id, transaction_client).await?;
         let (external_rm_relations, temp_rm_int_relations, mut removed_to_check) =
-            ModifyRelations::convert_relations(&self.0.remove_relations, resource_id, cache)?;
+            ModifyRelations::convert_relations(&self.0.remove_relations, resource_id, transaction_client).await?;
         if !temp_rm_int_relations
             .iter()
             .filter(|ir| ir.relation_name == INTERNAL_RELATION_VARIANT_VERSION)
@@ -88,10 +87,10 @@ impl ModifyRelations {
             resources_to_check: ulids_to_check,
         })
     }
-    fn convert_relations(
+    async fn convert_relations(
         api_relations: &Vec<Relation>,
         resource_id: DieselUlid,
-        cache: Arc<Cache>,
+        transaction_client: &Client,
     ) -> Result<(Vec<ExternalRelation>, Vec<InternalRelation>, Vec<Context>)> {
         let mut external_relations: Vec<ExternalRelation> = Vec::new();
         let mut internal_relations: Vec<InternalRelation> = Vec::new();
@@ -113,8 +112,8 @@ impl ModifyRelations {
                             .push(InternalRelation::from_api(
                                 internal,
                                 resource_id,
-                                cache.clone(),
-                            )?);
+                                transaction_client,
+                            ).await?);
                     }
                 }
             }

--- a/components/server/src/utils/conversions/relations.rs
+++ b/components/server/src/utils/conversions/relations.rs
@@ -1,5 +1,6 @@
-use std::{str::FromStr};
+use std::str::FromStr;
 
+use crate::database::dsls::object_dsl::Object;
 use crate::{
     auth::structs::Context,
     database::{
@@ -26,7 +27,6 @@ use aruna_rust_api::api::storage::models::v2::{
 use dashmap::DashMap;
 use diesel_ulid::DieselUlid;
 use tokio_postgres::Client;
-use crate::database::dsls::object_dsl::Object;
 
 pub fn from_db_internal_relation(internal: InternalRelation, inbound: bool) -> Relation {
     let (direction, resource_variant, resource_id) = if inbound {
@@ -127,13 +127,18 @@ impl InternalRelation {
     ) -> Result<Self> {
         match api_rel.direction() {
             aruna_rust_api::api::storage::models::v2::RelationDirection::Inbound => {
-                let self_obj = Object::get_object_with_relations(&related, transaction_client).await?;
-                    // .get_object(&related)
-                    // .ok_or_else(|| anyhow!("self_obj not found"))?;
-                let other_obj = Object::get_object_with_relations(&DieselUlid::from_str(&api_rel.resource_id)?, transaction_client).await?;
-                 //    cache
-                 //    .get_object(&DieselUlid::from_str(&api_rel.resource_id)?)
-                 //    .ok_or_else(|| anyhow!("other_obj not found"))?;
+                let self_obj =
+                    Object::get_object_with_relations(&related, transaction_client).await?;
+                // .get_object(&related)
+                // .ok_or_else(|| anyhow!("self_obj not found"))?;
+                let other_obj = Object::get_object_with_relations(
+                    &DieselUlid::from_str(&api_rel.resource_id)?,
+                    transaction_client,
+                )
+                .await?;
+                //    cache
+                //    .get_object(&DieselUlid::from_str(&api_rel.resource_id)?)
+                //    .ok_or_else(|| anyhow!("other_obj not found"))?;
 
                 if self_obj.object.object_type == other_obj.object.object_type
                     && api_rel.defined_variant == InternalRelationVariant::BelongsTo as i32
@@ -156,11 +161,16 @@ impl InternalRelation {
                 })
             }
             aruna_rust_api::api::storage::models::v2::RelationDirection::Outbound => {
-                let other_obj = Object::get_object_with_relations(&related, transaction_client).await?;
+                let other_obj =
+                    Object::get_object_with_relations(&related, transaction_client).await?;
                 //     cache
                 //     .get_object(&related)
                 //     .ok_or_else(|| anyhow!("self_obj not found"))?;
-                let self_obj = Object::get_object_with_relations(&DieselUlid::from_str(&api_rel.resource_id)?, transaction_client).await?;
+                let self_obj = Object::get_object_with_relations(
+                    &DieselUlid::from_str(&api_rel.resource_id)?,
+                    transaction_client,
+                )
+                .await?;
                 //     cache
                 //     .get_object(&DieselUlid::from_str(&api_rel.resource_id)?)
                 //     .ok_or_else(|| anyhow!("other_obj not found"))?;

--- a/components/server/src/utils/conversions/relations.rs
+++ b/components/server/src/utils/conversions/relations.rs
@@ -1,8 +1,7 @@
-use std::{str::FromStr, sync::Arc};
+use std::{str::FromStr};
 
 use crate::{
     auth::structs::Context,
-    caching::cache::Cache,
     database::{
         dsls::{
             internal_relation_dsl::{
@@ -26,6 +25,8 @@ use aruna_rust_api::api::storage::models::v2::{
 };
 use dashmap::DashMap;
 use diesel_ulid::DieselUlid;
+use tokio_postgres::Client;
+use crate::database::dsls::object_dsl::Object;
 
 pub fn from_db_internal_relation(internal: InternalRelation, inbound: bool) -> Relation {
     let (direction, resource_variant, resource_id) = if inbound {
@@ -118,19 +119,21 @@ impl From<DBExternalRelation> for ExternalRelation {
 }
 
 impl InternalRelation {
-    pub fn from_api(
+    pub async fn from_api(
         api_rel: &APIInternalRelation,
         related: DieselUlid,
-        cache: Arc<Cache>,
+        transaction_client: &Client,
+        // cache: Arc<Cache>,
     ) -> Result<Self> {
         match api_rel.direction() {
             aruna_rust_api::api::storage::models::v2::RelationDirection::Inbound => {
-                let self_obj = cache
-                    .get_object(&related)
-                    .ok_or_else(|| anyhow!("self_obj not found"))?;
-                let other_obj = cache
-                    .get_object(&DieselUlid::from_str(&api_rel.resource_id)?)
-                    .ok_or_else(|| anyhow!("other_obj not found"))?;
+                let self_obj = Object::get_object_with_relations(&related, transaction_client).await?;
+                    // .get_object(&related)
+                    // .ok_or_else(|| anyhow!("self_obj not found"))?;
+                let other_obj = Object::get_object_with_relations(&DieselUlid::from_str(&api_rel.resource_id)?, transaction_client).await?;
+                 //    cache
+                 //    .get_object(&DieselUlid::from_str(&api_rel.resource_id)?)
+                 //    .ok_or_else(|| anyhow!("other_obj not found"))?;
 
                 if self_obj.object.object_type == other_obj.object.object_type
                     && api_rel.defined_variant == InternalRelationVariant::BelongsTo as i32
@@ -153,12 +156,14 @@ impl InternalRelation {
                 })
             }
             aruna_rust_api::api::storage::models::v2::RelationDirection::Outbound => {
-                let other_obj = cache
-                    .get_object(&related)
-                    .ok_or_else(|| anyhow!("self_obj not found"))?;
-                let self_obj = cache
-                    .get_object(&DieselUlid::from_str(&api_rel.resource_id)?)
-                    .ok_or_else(|| anyhow!("other_obj not found"))?;
+                let other_obj = Object::get_object_with_relations(&related, transaction_client).await?;
+                //     cache
+                //     .get_object(&related)
+                //     .ok_or_else(|| anyhow!("self_obj not found"))?;
+                let self_obj = Object::get_object_with_relations(&DieselUlid::from_str(&api_rel.resource_id)?, transaction_client).await?;
+                //     cache
+                //     .get_object(&DieselUlid::from_str(&api_rel.resource_id)?)
+                //     .ok_or_else(|| anyhow!("other_obj not found"))?;
 
                 if self_obj.object.object_type == other_obj.object.object_type
                     && api_rel.defined_variant == InternalRelationVariant::BelongsTo as i32

--- a/components/server/tests/middlelayer/relations.rs
+++ b/components/server/tests/middlelayer/relations.rs
@@ -95,8 +95,7 @@ async fn test_modify() {
         });
     }
 
-    let cache = db_handler.cache.clone();
-    let (obj, mod_lab) = db_handler.get_resource(request, cache).await.unwrap();
+    let (obj, mod_lab) = db_handler.get_resource(request).await.unwrap();
     let owr = db_handler
         .modify_relations(obj, mod_lab.relations_to_add, mod_lab.relations_to_remove)
         .await
@@ -269,8 +268,7 @@ async fn test_modify_relations_constraint() {
         remove_relations: vec![invalid],
     });
 
-    let cache = db_handler.cache.clone();
-    let (obj, mod_lab) = db_handler.get_resource(request, cache).await.unwrap();
+    let (obj, mod_lab) = db_handler.get_resource(request).await.unwrap();
     assert!(db_handler
         .modify_relations(obj, mod_lab.relations_to_add, mod_lab.relations_to_remove)
         .await
@@ -292,8 +290,7 @@ async fn test_modify_relations_constraint() {
         remove_relations: vec![invalid],
     });
 
-    let cache = db_handler.cache.clone();
-    let (obj, mod_lab) = db_handler.get_resource(request, cache).await.unwrap();
+    let (obj, mod_lab) = db_handler.get_resource(request).await.unwrap();
     assert!(db_handler
         .modify_relations(obj, mod_lab.relations_to_add, mod_lab.relations_to_remove)
         .await
@@ -315,8 +312,7 @@ async fn test_modify_relations_constraint() {
         remove_relations: vec![valid],
     });
 
-    let cache = db_handler.cache.clone();
-    let (obj, mod_lab) = db_handler.get_resource(request, cache).await.unwrap();
+    let (obj, mod_lab) = db_handler.get_resource(request).await.unwrap();
     assert!(db_handler
         .modify_relations(obj, mod_lab.relations_to_add, mod_lab.relations_to_remove)
         .await


### PR DESCRIPTION
### Summary

Fix for `CreateRequests`. 

### Description

Due to the rules update, all changes to resources are captured by a database transaction, to check for possible rule violations in the changed state. Added relations were checked in the cache, where the changed state was not present. This check is now done via the database and a `transaction_client`.