### PR TITLE
Fix/presigned urls

### DIFF
--- a/components/server/src/grpc/object.rs
+++ b/components/server/src/grpc/object.rs
@@ -127,9 +127,9 @@ impl ObjectService for ObjectServiceImpl {
         let request = PresignedUpload(request.into_inner());
 
         let object_id = tonic_invalid!(request.get_id(), "Invalid id");
-        let user_id = tonic_auth!(
+        let PermissionCheck { user_id, token, .. } = tonic_auth!(
             self.authorizer
-                .check_permissions(
+                .check_permissions_verbose(
                     &token,
                     vec![Context::res_ctx(object_id, DbPermissionLevel::WRITE, true)]
                 )
@@ -144,6 +144,7 @@ impl ObjectService for ObjectServiceImpl {
                     request,
                     self.authorizer.clone(),
                     user_id,
+                    token,
                 )
                 .await,
             "Error while building presigned url"

--- a/components/server/src/grpc/object.rs
+++ b/components/server/src/grpc/object.rs
@@ -169,9 +169,9 @@ impl ObjectService for ObjectServiceImpl {
         let request = PresignedDownload(request.into_inner());
 
         let object_id = tonic_invalid!(request.get_id(), "Invalid id");
-        let user_id = tonic_auth!(
+        let PermissionCheck { user_id, token, .. } = tonic_auth!(
             self.authorizer
-                .check_permissions(
+                .check_permissions_verbose(
                     &token,
                     vec![Context::res_ctx(object_id, DbPermissionLevel::READ, true)]
                 )
@@ -186,6 +186,7 @@ impl ObjectService for ObjectServiceImpl {
                     self.authorizer.clone(),
                     request,
                     user_id,
+                    token,
                 )
                 .await,
             "Error while building presigned url"

--- a/components/server/src/middlelayer/presigned_url_handler.rs
+++ b/components/server/src/middlelayer/presigned_url_handler.rs
@@ -124,6 +124,7 @@ impl DatabaseHandler {
         authorizer: Arc<PermissionHandler>,
         request: PresignedDownload,
         user_id: DieselUlid,
+        token: Option<DieselUlid>,
     ) -> Result<String> {
         let object_id = request.get_id()?;
         let (project_id, bucket_name, key) =
@@ -145,7 +146,7 @@ impl DatabaseHandler {
         }
 
         let (_, endpoint_s3_url, ssl, credentials) =
-            DatabaseHandler::get_credentials(authorizer, user_id, None, endpoint).await?;
+            DatabaseHandler::get_credentials(authorizer, user_id, token, endpoint).await?;
         let url = sign_download_url(
             &credentials.access_key,
             &credentials.secret_key,

--- a/components/server/src/middlelayer/presigned_url_handler.rs
+++ b/components/server/src/middlelayer/presigned_url_handler.rs
@@ -162,6 +162,7 @@ impl DatabaseHandler {
         request: PresignedUpload,
         authorizer: Arc<PermissionHandler>,
         user_id: DieselUlid,
+        token: Option<DieselUlid>,
     ) -> Result<String> {
         let object_id = request.get_id()?;
         let multipart = request.get_multipart();
@@ -172,7 +173,7 @@ impl DatabaseHandler {
 
         let endpoint = self.get_project_endpoint(project_id, cache.clone()).await?;
         let (endpoint_host_url, endpoint_s3_url, ssl, credentials) =
-            DatabaseHandler::get_credentials(authorizer, user_id, None, endpoint).await?;
+            DatabaseHandler::get_credentials(authorizer, user_id, token, endpoint).await?;
         let upload_id = if multipart {
             DatabaseHandler::impersonated_multi_upload_init(
                 &credentials.access_key,


### PR DESCRIPTION
# Summary
Fixes presigned urls with aruna tokens

# Description
When creating a presigned url, the `token id` returned by the authorization was not shared with the underlying `get_credentials` function in `get_presigend_upload`/`get_presigned_download`