### PR TITLE
Fix get_resource 

### DIFF
--- a/components/server/src/grpc/search.rs
+++ b/components/server/src/grpc/search.rs
@@ -156,7 +156,7 @@ impl SearchService for SearchServiceImpl {
                     let mut permission = PermissionLevel::Read;
                     for (id, perm) in user.attributes.0.permissions.clone() {
                         let all_subs = self.cache.get_subresources(&id).unwrap_or_default(); // This is empty if unwrap fails -> should not affect anything
-                        if all_subs.iter().contains(&id) {
+                        if all_subs.contains(&resource_ulid) {
                             let tmp_perm: DbPermissionLevel = match perm {
                                 ObjectMapping::OBJECT(perm) => perm,
                                 ObjectMapping::COLLECTION(perm) => perm,

--- a/components/server/src/grpc/search.rs
+++ b/components/server/src/grpc/search.rs
@@ -153,7 +153,7 @@ impl SearchService for SearchServiceImpl {
                     (object, permission, bindings)
                 }
                 Err(_) => {
-                    let mut permission = PermissionLevel::Read;
+                    let mut permission = PermissionLevel::None;
                     for (id, perm) in user.attributes.0.permissions.clone() {
                         let all_subs = self.cache.get_subresources(&id).unwrap_or_default(); // This is empty if unwrap fails -> should not affect anything
                         if all_subs.contains(&resource_ulid) {
@@ -206,7 +206,7 @@ impl SearchService for SearchServiceImpl {
                 .collect::<Vec<_>>();
 
             object_plus.object.key_values = Json(KeyValues(stripped_labels));
-            (object_plus, PermissionLevel::Read, bindings)
+            (object_plus, PermissionLevel::None, bindings)
         };
         self.cache.add_stats_to_object(&mut object_plus);
 
@@ -299,7 +299,7 @@ impl SearchService for SearchServiceImpl {
                         objects.push((object, permission, bindings));
                     }
                     Err(_) => {
-                        let mut permission = PermissionLevel::Read;
+                        let mut permission = PermissionLevel::None;
                         for (id, perm) in user.attributes.0.permissions.clone() {
                             let all_subs = self.cache.get_subresources(&id).unwrap_or_default();
                             if all_subs.iter().contains(&id) {
@@ -354,7 +354,7 @@ impl SearchService for SearchServiceImpl {
                     .collect::<Vec<_>>();
 
                 object_plus.object.key_values = Json(KeyValues(stripped_labels));
-                objects.push((object_plus, PermissionLevel::Read, bindings));
+                objects.push((object_plus, PermissionLevel::None, bindings));
             }
             objects
         };


### PR DESCRIPTION
# Summary

`get_resource()` now returns the correct permission a user has for the resource or `PermissionLevel::None` if the user does not have permissions on the resource or is not authenticated at all.