### PR TITLE
fix: Update presign handler

### DIFF
--- a/components/server/src/middlelayer/hooks_request_types.rs
+++ b/components/server/src/middlelayer/hooks_request_types.rs
@@ -322,7 +322,7 @@ impl CustomTemplate {
         object: &Object,
         secret: String,
         download_url: Option<String>,
-        upload_credentials: Option<GetCredentialsResponse>,
+        upload_credentials: GetCredentialsResponse,
         pubkey_serial: i32,
     ) -> Result<String> {
         let object_status = match object.object_status {
@@ -339,10 +339,10 @@ impl CustomTemplate {
             DataClass::WORKSPACE => "WORKSPACE".to_string(),
             DataClass::CONFIDENTIAL => "CONFIDENTIAL".to_string(),
         };
-        let (access_key, secret_key) = match upload_credentials {
-            Some(creds) => (creds.access_key, creds.secret_key),
-            None => (String::new(), String::new()),
-        };
+        let GetCredentialsResponse {
+            access_key,
+            secret_key,
+        } = upload_credentials;
         let download_url = download_url.unwrap_or_default();
         let replacement_pairs = [
             (r"\{\{secret\}\}", secret),

--- a/components/server/src/middlelayer/workspace_db_handler.rs
+++ b/components/server/src/middlelayer/workspace_db_handler.rs
@@ -130,8 +130,14 @@ impl DatabaseHandler {
                 access_key,
                 secret_key,
             },
-        ) = DatabaseHandler::get_credentials(authorizer.clone(), service_user.id, None, default)
-            .await?;
+        ) = DatabaseHandler::get_or_create_credentials(
+            authorizer.clone(),
+            service_user.id,
+            None,
+            default,
+            false,
+        )
+        .await?;
 
         Ok((workspace.id, access_key, secret_key, token_secret))
     }


### PR DESCRIPTION
This small upgrade fixes an regression in the pre-signed URL handler.

Previous iterations had a GetOrCreate method for fetching Credentials from a proxy. This was changed during the 2.0 update resulting in an unauthorized error when making a Get call before a create call.

This update reverts this behavior on the server site.
It also simplifies and removes some unnecessary redundancy in the hook handling logic.