### PR TITLE
Fix/hooks

### DIFF
--- a/components/server/src/hooks/hook_handler.rs
+++ b/components/server/src/hooks/hook_handler.rs
@@ -406,7 +406,7 @@ impl HookHandler {
                 .create_hook_token(&user_id, append_only_token)
                 .await?;
 
-            tokio::time::sleep(Duration::from_secs(10)).await;
+            // tokio::time::sleep(Duration::from_secs(10)).await;
 
             // Create download url for response
             let request = PresignedDownload(GetDownloadUrlRequest {

--- a/components/server/src/hooks/hook_handler.rs
+++ b/components/server/src/hooks/hook_handler.rs
@@ -405,8 +405,6 @@ impl HookHandler {
                 .create_hook_token(&user_id, append_only_token)
                 .await?;
 
-            // tokio::time::sleep(Duration::from_secs(10)).await;
-
             // Create download url for response
             let request = PresignedDownload(GetDownloadUrlRequest {
                 object_id: object_id.to_string(),

--- a/components/server/src/hooks/hook_handler.rs
+++ b/components/server/src/hooks/hook_handler.rs
@@ -29,7 +29,6 @@ use async_channel::Receiver;
 use diesel_ulid::DieselUlid;
 use reqwest::header::CONTENT_TYPE;
 use std::sync::Arc;
-use std::time::Duration;
 
 #[derive(Clone)]
 pub struct HookHandler {

--- a/components/server/src/middlelayer/presigned_url_handler.rs
+++ b/components/server/src/middlelayer/presigned_url_handler.rs
@@ -42,16 +42,13 @@ impl DatabaseHandler {
         user_id: DieselUlid,
         token_id: Option<DieselUlid>,
     ) -> Result<(String, GetCredentialsResponse)> {
-        dbg!("Start");
         let object_id = request.get_id()?;
 
         let (project_id, bucket_name, key) =
             DatabaseHandler::get_path(object_id, cache.clone()).await?;
 
-        dbg!("path");
         let endpoint = self.get_project_endpoint(project_id, cache.clone()).await?;
 
-        dbg!("endpoint");
         let mut backoff_counter = 0;
         while backoff_counter <= *MAX_RETRIES {
             match DatabaseHandler::get_or_create_credentials(
@@ -65,7 +62,6 @@ impl DatabaseHandler {
             {
                 Ok(response) => {
                     let (_, endpoint_s3_url, ssl, credentials) = response;
-                    dbg!("get/create creds");
                     let url = sign_download_url(
                         &credentials.access_key,
                         &credentials.secret_key,
@@ -74,7 +70,6 @@ impl DatabaseHandler {
                         &key,
                         &endpoint_s3_url,
                     )?;
-                    dbg!("sign url");
                     return Ok((url, credentials));
                 }
                 Err(err) => {


### PR DESCRIPTION
# Summary
This is a hotfix for hook services

# Changes
- Adding labels in hook callbacks were overwritten by the old object state
- JSON request parsing for hook services fixed
- Retries for `get_or_create_credentials` because newly created tokens are not synced with proxies