### PR TITLE
fix: Fixed upsert user comparison

### DIFF
--- a/components/data_proxy/src/caching/cache.rs
+++ b/components/data_proxy/src/caching/cache.rs
@@ -642,7 +642,7 @@ impl Cache {
         let proxy_user = User::try_from(user)?;
         let (to_update, to_delete) = if let Some(user) = self.users.get(&user_id) {
             let mut user = user.value().write().await;
-            let comparison = proxy_user.compare_permissions(&user.0);
+            let comparison = user.0.compare_permissions(&proxy_user);
             let new_keys = user
                 .1
                 .iter()

--- a/components/data_proxy/src/structs.rs
+++ b/components/data_proxy/src/structs.rs
@@ -375,8 +375,8 @@ pub struct User {
 
 impl User {
     pub fn compare_permissions(
-        &self,
-        other: &User,
+        &self,        // GRPC user
+        other: &User, // database user
     ) -> (
         Vec<(String, HashMap<DieselUlid, DbPermissionLevel>)>,
         Vec<String>,


### PR DESCRIPTION
Comparing permissions was switched, resulting in no permission updates