### PR TITLE
fix: clone_object permission check

### DIFF
--- a/components/server/src/grpc/object.rs
+++ b/components/server/src/grpc/object.rs
@@ -352,7 +352,7 @@ impl ObjectService for ObjectServiceImpl {
         let object_id = tonic_invalid!(request.get_object_id(), "Invalid object id");
         let (parent_id, parent_mapping) = tonic_invalid!(request.get_parent(), "Invalid object id");
         let parent_ctx = Context::res_ctx(parent_id, DbPermissionLevel::APPEND, true);
-        let object_ctx = Context::res_ctx(parent_id, DbPermissionLevel::READ, true);
+        let object_ctx = Context::res_ctx(object_id, DbPermissionLevel::READ, true);
         let user_id = tonic_auth!(
             self.authorizer
                 .check_permissions(&token, vec![parent_ctx, object_ctx])

--- a/components/server/src/grpc/object.rs
+++ b/components/server/src/grpc/object.rs
@@ -351,9 +351,12 @@ impl ObjectService for ObjectServiceImpl {
         let request = CloneObject(request.into_inner());
         let object_id = tonic_invalid!(request.get_object_id(), "Invalid object id");
         let (parent_id, parent_mapping) = tonic_invalid!(request.get_parent(), "Invalid object id");
-        let ctx = Context::res_ctx(parent_id, DbPermissionLevel::WRITE, true);
+        let parent_ctx = Context::res_ctx(parent_id, DbPermissionLevel::APPEND, true);
+        let object_ctx = Context::res_ctx(parent_id, DbPermissionLevel::READ, true);
         let user_id = tonic_auth!(
-            self.authorizer.check_permissions(&token, vec![ctx]).await,
+            self.authorizer
+                .check_permissions(&token, vec![parent_ctx, object_ctx])
+                .await,
             "Unauthorized"
         );
         let new = tonic_internal!(


### PR DESCRIPTION
This adds an additional permission check for cloned_objects and updates needed parent permissions from `WRITE` to `APPEND`