### PR TITLE
feat: Config option to force deprecated path style buckets in s3 backend

### DIFF
--- a/components/data_proxy/config.toml
+++ b/components/data_proxy/config.toml
@@ -37,6 +37,7 @@ encryption=true
 compression=true
 deduplication=true # COMING SOON If deduplication is enabled, the backend will check if an object with the same hash already exists and return the existing object if it does
 tmp="tmp12345" # Will generate a random temp bucket_name if not set
+force_path_style=false # Set, if s3 backend is not supporting subdomains
 # dropbox_bucket="" # Set value to set a dropbox bucket
 # A scheme for the backend to use when deciding where to store objects
 # The following variables are available:

--- a/components/data_proxy/src/config.rs
+++ b/components/data_proxy/src/config.rs
@@ -179,6 +179,7 @@ pub enum Backend {
         encryption: bool,
         compression: bool,
         deduplication: bool,
+        force_path_style: Option<bool>,
         dropbox_bucket: Option<String>,
         backend_scheme: String,
         tmp: Option<String>,

--- a/components/data_proxy/src/data_backends/s3_backend.rs
+++ b/components/data_proxy/src/data_backends/s3_backend.rs
@@ -45,6 +45,7 @@ impl S3Backend {
             encryption,
             compression,
             dropbox_bucket,
+            force_path_style,
             ..
         } = &CONFIG.backend
         else {
@@ -62,10 +63,17 @@ impl S3Backend {
 
         #[allow(deprecated)]
         let config = aws_config::load_from_env().await;
-        let s3_config = aws_sdk_s3::config::Builder::from(&config)
-            .region(Region::new("RegionOne"))
-            .endpoint_url(&s3_endpoint)
-            .build();
+        let s3_config = match force_path_style {
+            Some(force_path_style) => aws_sdk_s3::config::Builder::from(&config)
+                .region(Region::new("RegionOne"))
+                .force_path_style(*force_path_style)
+                .endpoint_url(&s3_endpoint)
+                .build(),
+            _ => aws_sdk_s3::config::Builder::from(&config)
+                .region(Region::new("RegionOne"))
+                .endpoint_url(&s3_endpoint)
+                .build(),
+        };
 
         let s3_client = Client::from_conf(s3_config);
 


### PR DESCRIPTION
This adds a config value for path-style buckets, to address legacy (and deprecated) s3 backend configurations