### PR TITLE
CORS exception regex

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -1356,6 +1356,7 @@ dependencies = [
  "postgres_array",
  "prost-wkt-types",
  "rand",
+ "regex",
  "reqsign",
  "reqwest",
  "s3s",
@@ -3576,9 +3577,9 @@ dependencies = [
 
 [[package]]
 name = "regex"
-version = "1.10.3"
+version = "1.10.4"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "b62dbe01f0b06f9d8dc7d49e05a0785f153b00b2c227856282f671e0318c9b15"
+checksum = "c117dbdfde9c8308975b6a18d71f3f385c89461f7b3fb054288ecf2a2058ba4c"
 dependencies = [
  "aho-corasick",
  "memchr",

--- a/components/data_proxy/.env
+++ b/components/data_proxy/.env
@@ -1,8 +1,13 @@
 # Private ed25519 key of the proxy
 PROXY_PRIVATE_KEY=MC4CAQAwBQYDK2VwBCIEIM/FI+bYw+auSKGyGqeISRIEjofvZV/lbK7QL1wkuCey
 POSTGRES_PASSWORD=yugabyte
+
 # Local deployment
 PERSISTENCE_DB_SCHEMA='./src/database/schema.sql'
+
+# Regex for origins that receive CORS headers with * in the response
+CORS_EXCEPTION='http://localhost:3000'
+
 # Backend config (default = S3)
 AWS_S3_HOST=http://localhost:9000
 AWS_ACCESS_KEY_ID=minioadmin

--- a/components/data_proxy/.env
+++ b/components/data_proxy/.env
@@ -5,9 +5,6 @@ POSTGRES_PASSWORD=yugabyte
 # Local deployment
 PERSISTENCE_DB_SCHEMA='./src/database/schema.sql'
 
-# Regex for origins that receive CORS headers with * in the response
-CORS_EXCEPTION='http://localhost:3000'
-
 # Backend config (default = S3)
 AWS_S3_HOST=http://localhost:9000
 AWS_ACCESS_KEY_ID=minioadmin

--- a/components/data_proxy/Cargo.toml
+++ b/components/data_proxy/Cargo.toml
@@ -52,6 +52,7 @@ postgres-types = {workspace = true}
 postgres_array = "0.11.1"
 prost-wkt-types = {workspace = true}
 rand = {workspace = true}
+regex = "1.10.4"
 reqsign = "0.15.0"
 reqwest = {workspace = true}
 s3s = "0.9.0"

--- a/components/data_proxy/config.toml
+++ b/components/data_proxy/config.toml
@@ -25,6 +25,7 @@ schema = './src/database/schema.sql'
 [frontend]
 server="0.0.0.0:1337"
 hostname="localhost:1337"
+cors_exception="http://localhost:3000"
 
 [backend.s3]
 # s3 host

--- a/components/data_proxy/src/config.rs
+++ b/components/data_proxy/src/config.rs
@@ -167,6 +167,7 @@ impl Persistence {
 pub struct Frontend {
     pub server: String,
     pub hostname: String,
+    pub cors_exception: Option<String>,
 }
 
 #[derive(Debug, Serialize, Deserialize)]

--- a/components/data_proxy/src/main.rs
+++ b/components/data_proxy/src/main.rs
@@ -12,6 +12,7 @@ use grpc_api::{
     proxy_service::DataproxyReplicationServiceImpl, user_service::DataproxyUserServiceImpl,
 };
 use lazy_static::lazy_static;
+use regex::Regex;
 use std::panic;
 use std::{net::SocketAddr, sync::Arc};
 use tokio::try_join;
@@ -51,6 +52,14 @@ lazy_static! {
             toml::from_str(std::fs::read_to_string(config_file).unwrap().as_str()).unwrap();
         config.validate().unwrap();
         config
+    };
+    static ref CORS_REGEX: Option<Regex> = {
+        if let Some(frontend) = &CONFIG.frontend {
+            if let Some(cors_regex) = &frontend.cors_exception {
+                return Some(Regex::new(cors_regex).expect("CORS exception regex invalid"));
+            }
+        }
+        None
     };
 }
 

--- a/components/data_proxy/src/s3_frontend/s3service.rs
+++ b/components/data_proxy/src/s3_frontend/s3service.rs
@@ -1127,7 +1127,7 @@ impl S3 for ArunaS3Service {
         let CheckAccessResult {
             objects_state,
             user_state,
-            ..
+            headers,
         } = req
             .extensions
             .get::<CheckAccessResult>()
@@ -1433,7 +1433,20 @@ impl S3 for ArunaS3Service {
             ..Default::default()
         };
         debug!(?output);
-        Ok(S3Response::new(output))
+
+        let mut resp = S3Response::new(output);
+        if let Some(headers) = headers {
+            for (k, v) in headers {
+                resp.headers.insert(
+                    HeaderName::from_bytes(k.as_bytes())
+                        .map_err(|_| s3_error!(InternalError, "Unable to parse header name"))?,
+                    HeaderValue::from_str(&v)
+                        .map_err(|_| s3_error!(InternalError, "Unable to parse header value"))?,
+                );
+            }
+        }
+
+        Ok(resp)
     }
 
     #[tracing::instrument(err)]
@@ -1457,7 +1470,11 @@ impl S3 for ArunaS3Service {
             }
         };
 
-        let CheckAccessResult { objects_state, .. } = req
+        let CheckAccessResult {
+            objects_state,
+            headers,
+            ..
+        } = req
             .extensions
             .get::<CheckAccessResult>()
             .cloned()
@@ -1562,6 +1579,19 @@ impl S3 for ArunaS3Service {
             ..Default::default()
         };
         debug!(?output);
-        Ok(S3Response::new(output))
+
+        let mut resp = S3Response::new(output);
+        if let Some(headers) = headers {
+            for (k, v) in headers {
+                resp.headers.insert(
+                    HeaderName::from_bytes(k.as_bytes())
+                        .map_err(|_| s3_error!(InternalError, "Unable to parse header name"))?,
+                    HeaderValue::from_str(&v)
+                        .map_err(|_| s3_error!(InternalError, "Unable to parse header value"))?,
+                );
+            }
+        }
+
+        Ok(resp)
     }
 }

--- a/components/server/tests/database/relations.rs
+++ b/components/server/tests/database/relations.rs
@@ -335,7 +335,7 @@ async fn get_by() {
     Object::batch_create(&vec![create_project, create_collection], client)
         .await
         .unwrap();
-    InternalRelation::batch_create(&vec![relation_one], client)
+    InternalRelation::batch_create(&[relation_one], client)
         .await
         .unwrap();
 


### PR DESCRIPTION
Adds a config parameter that can be used to set CORS exceptions for certain origins via regex.

Requests with an `Origin` header whose value matches the regex always receive the following CORS response headers in the response:
- `Access-Control-Allow-Origin: *`
- `Access-Control-Allow-Methods: *`
- `Access-Control-Allow-Headers: *`

This allows the operators of a DataProxy to release its resources for interactions with certain applications. If the parameter is not set, only the set bucket CORS rules are applied as before.