### PR TITLE
fix: Incorrect evaluation if object was initialized

### DIFF
--- a/components/data_proxy/src/s3_frontend/s3service.rs
+++ b/components/data_proxy/src/s3_frontend/s3service.rs
@@ -1185,7 +1185,7 @@ impl S3 for ArunaS3Service {
                     new_revision.synced = false;
                     new_revision.children = None;
                     new_revision.dynamic = false;
-                    (new_revision, false)
+                    (new_revision, true)
                 }
             }
             NewOrExistingObject::Missing(object) => (object, false),


### PR DESCRIPTION
This addresses a bug in the `put_object` process where the system incorrectly evaluated whether an updated object was initialized which leads to an error when the system tries to create a duplicate of the already existing object after the upload.

## Impact

This fix ensures that the system accurately tracks whether a new object has been initialized on update through the data proxy's S3 interface and does not erroneously attempt to create a duplicate.