### PR TITLE
Mail notifications

### DIFF
--- a/components/server/src/grpc/users.rs
+++ b/components/server/src/grpc/users.rs
@@ -11,6 +11,7 @@ use crate::middlelayer::user_request_types::{
 };
 use crate::utils::conversions::users::{as_api_token, convert_token_to_proto};
 use crate::utils::grpc_utils::get_token_from_md;
+use crate::utils::mailclient::MailClient;
 use anyhow::anyhow;
 use aruna_rust_api::api::storage::models::v2::context::Context as ProtoContext;
 use aruna_rust_api::api::storage::services::v2::user_service_server::UserService;
@@ -39,7 +40,7 @@ use diesel_ulid::DieselUlid;
 use std::str::FromStr;
 use std::sync::Arc;
 use tonic::{Request, Response, Status};
-crate::impl_grpc_server!(UserServiceImpl, token_handler: Arc<TokenHandler>);
+crate::impl_grpc_server!(UserServiceImpl, token_handler: Arc<TokenHandler>, mailclient: Arc<Option<MailClient>>);
 
 #[tonic::async_trait]
 impl UserService for UserServiceImpl {

--- a/components/server/src/grpc/users.rs
+++ b/components/server/src/grpc/users.rs
@@ -82,7 +82,7 @@ impl UserService for UserServiceImpl {
                 &user.email,
                 format!("Dear {},
 We are excited to inform you that your registration with Aruna has been successfully completed.\n
-After your account has been activated by an administrator you can start exploring all the features we offer. Should you need any assistance or have any questions, you can create support tickets by reaching out to us at support@aruna-storage.org.\n
+After your account has been activated by an administrator, you can start exploring all the features we offer. Should you need any assistance or have any questions, you can create support tickets by reaching out to us at support@aruna-storage.org.\n
 Thank you for joining us, and we look forward to supporting you on your journey!\n
 With kind regards,
 the Aruna team", user.display_name),

--- a/components/server/src/main.rs
+++ b/components/server/src/main.rs
@@ -183,10 +183,10 @@ pub async fn main() -> Result<()> {
     .await;
 
     // init MailClient
-    let _: Option<MailClient> = if !dotenvy::var("ARUNA_DEV_ENV")?.parse::<bool>()? {
-        Some(MailClient::new()?)
+    let mailclient: Arc<Option<MailClient>> = if !dotenvy::var("ARUNA_DEV_ENV")?.parse::<bool>()? {
+        Arc::new(Some(MailClient::new()?))
     } else {
-        None
+        Arc::new(None)
     };
 
     let default_endpoint = dotenvy::var("DEFAULT_DATAPROXY_ULID")?;
@@ -228,6 +228,7 @@ pub async fn main() -> Result<()> {
                     auth_arc.clone(),
                     cache_arc.clone(),
                     token_handler_arc.clone(),
+                    mailclient.clone(),
                 )
                 .await,
             ))

--- a/components/server/src/middlelayer/user_db_handler.rs
+++ b/components/server/src/middlelayer/user_db_handler.rs
@@ -44,7 +44,7 @@ impl DatabaseHandler {
         &self,
         request: RegisterUser,
         external_id: OIDCMapping,
-    ) -> Result<DieselUlid> {
+    ) -> Result<User> {
         let client = self.database.get_client().await?;
         let user_id = DieselUlid::generate();
         let new_attributes = UserAttributes {
@@ -86,7 +86,7 @@ impl DatabaseHandler {
             return Err(anyhow::anyhow!("Notification emission failed"));
         }
 
-        Ok(user_id)
+        Ok(user)
     }
 
     pub async fn deactivate_user(&self, request: DeactivateUser) -> Result<User> {

--- a/components/server/tests/common/init.rs
+++ b/components/server/tests/common/init.rs
@@ -317,7 +317,7 @@ pub async fn init_user_service_manual(
     token_handler: Arc<TokenHandler>,
 ) -> UserServiceImpl {
     // Init authorization service
-    UserServiceImpl::new(db, auth, cache, token_handler).await
+    UserServiceImpl::new(db, auth, cache, token_handler, Arc::new(None)).await
 }
 
 #[allow(dead_code)]


### PR DESCRIPTION
This re-implements mail notifications for users upon registration and activation.

## Changes

Mail notification is sent to the email address provided by the user:
* After a successful `RegisterUserRequest` 
* After a success `ActivateUserRequest`

But only in case the config parameter `ARUNA_DEV_ENV` is set to `true` and valid values for the SMTP server are also provided.

## Outlook

If it turns out that in the future even more mail notifications are to be sent directly via the Aruna server, you could think about a kind of template or configuration to overwrite the hard-coded mail content.