### PR TITLE
Fix filter for resource key-values and project exists query

### DIFF
--- a/components/server/src/database/dsls/object_dsl.rs
+++ b/components/server/src/database/dsls/object_dsl.rs
@@ -984,7 +984,7 @@ impl Object {
             COALESCE(JSON_OBJECT_AGG(ir1.target_pid, ir1.*) FILTER (WHERE ir1.origin_pid = o.id AND ir1.relation_name = 'BELONGS_TO'), '{}') outbound_belongs_to
             FROM objects o
             LEFT OUTER JOIN internal_relations ir1 ON o.id IN (ir1.target_pid, ir1.origin_pid)
-            WHERE o.name = $1 
+            WHERE o.name = $1 AND o.object_type = 'PROJECT'
             GROUP BY o.id;";
         let prepared = client.prepare(query).await?;
         let result: Option<ObjectWithRelations> = client

--- a/components/server/src/grpc/search.rs
+++ b/components/server/src/grpc/search.rs
@@ -201,8 +201,8 @@ impl SearchService for SearchServiceImpl {
                 .0
                  .0
                 .into_iter()
-                .filter(|kv| kv.key.contains("app.aruna-storage"))
-                .filter(|kv| kv.key.contains("private"))
+                .filter(|kv| !kv.key.contains("app.aruna-storage"))
+                .filter(|kv| !kv.key.contains("private"))
                 .collect::<Vec<_>>();
 
             object_plus.object.key_values = Json(KeyValues(stripped_labels));
@@ -349,8 +349,8 @@ impl SearchService for SearchServiceImpl {
                     .0
                      .0
                     .into_iter()
-                    .filter(|kv| kv.key.contains("app.aruna-storage"))
-                    .filter(|kv| kv.key.contains("private"))
+                    .filter(|kv| !kv.key.contains("app.aruna-storage"))
+                    .filter(|kv| !kv.key.contains("private"))
                     .collect::<Vec<_>>();
 
                 object_plus.object.key_values = Json(KeyValues(stripped_labels));


### PR DESCRIPTION
## Changes

* Resource fetch without token now correctly filters key-values tagged as private or internal
* Check if project exists now does not incorrectly include its direct children anymore