### PR TITLE
StorageStatusServer announcements API implementation

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -95,9 +95,9 @@ checksum = "96d30a06541fbafbc7f82ed10c06164cfbd2c401138f6addd8404629c4b16711"
 
 [[package]]
 name = "aruna-rust-api"
-version = "2.0.0-beta.14.1"
+version = "2.0.0-beta.15.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "e2a2464105fc7dc794c46f219b89feb7abc5bb7858e6c564981a9da89828d240"
+checksum = "258b583534f08f570e1af6345b492ae446597a131e44cff89682110168d2992e"
 dependencies = [
  "prost",
  "prost-types",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -14,7 +14,7 @@ license = "MIT OR Apache-2.0"
 [workspace.dependencies]
 ahash = "0.8.11"
 anyhow = "1.0.81"
-aruna-rust-api = "2.0.0-beta.14.1"
+aruna-rust-api = "2.0.0-beta.15.1"
 async-channel = "2.2.0"
 async-trait = "0.1.77"
 aws-config = "1.1.7"

--- a/components/server/.env
+++ b/components/server/.env
@@ -9,16 +9,14 @@ ARUNA_DEV_ENV=true
 #SMTP_SEND_ADDRESS=''
 
 # Database
-#DATABASE_URL=postgres://root:test123@localhost:26257/test
 DATABASE_HOST=localhost
 DATABASE_DB=test
 DATABASE_PORT=5433
 DATABASE_USER=yugabyte
 DATABASE_PASSWORD=yugabyte
+
 # Local deployment
 DATABASE_SCHEMA='./src/database/schema.sql'
-# Dockerfile
-#DATABASE_SCHEMA='./schema.sql'
 
 # Default Endpoint
 DEFAULT_DATAPROXY_ULID='01H81W0ZMB54YEP5711Q2BK46V'
@@ -31,7 +29,7 @@ DECODING_KEY='MCowBQYDK2VwAyEA2YfYTgb8Y0LTFr+2Rm2Fkdu38eJTfnsMDH2iZHErBH0='
 MEILISEARCH_HOST=http://localhost:7700
 MEILISEARCH_API_KEY=MASTER_KEY
 
-# Even Notifications
+# Event Notifications
 NATS_HOST=localhost:4222
 REPLY_SECRET=ThisIsASecretToken
 

--- a/components/server/src/database/dsls/info_dsl.rs
+++ b/components/server/src/database/dsls/info_dsl.rs
@@ -1,0 +1,148 @@
+use crate::database::crud::{CrudDb, PrimaryKey};
+use crate::utils::database_utils::create_multi_query;
+use chrono::NaiveDateTime;
+use diesel_ulid::DieselUlid;
+use postgres_from_row::FromRow;
+use postgres_types::ToSql;
+use tokio_postgres::Client;
+
+#[derive(FromRow, Debug, Clone)]
+pub struct Announcement {
+    pub id: DieselUlid,
+    pub announcement_type: String,
+    pub content: String,
+    pub created_by: DieselUlid,
+    pub created_at: NaiveDateTime,
+    pub last_modified_by: DieselUlid,
+    pub last_modified_at: NaiveDateTime,
+}
+
+#[async_trait::async_trait]
+impl CrudDb for Announcement {
+    async fn create(&mut self, client: &Client) -> anyhow::Result<()> {
+        let query = "INSERT INTO announcements (id, announcement_type, content, created_by, created_at, last_modified_by, last_modified_at)
+            VALUES ($1, $2, $3, $4, $5, $6, $7)
+            RETURNING *;";
+
+        let prepared = client.prepare(query).await?;
+
+        let row = client
+            .query_one(
+                &prepared,
+                &[
+                    &self.id,
+                    &self.announcement_type,
+                    &self.content,
+                    &self.created_by,
+                    &self.created_at,
+                    &self.last_modified_by,
+                    &self.last_modified_at,
+                ],
+            )
+            .await?;
+
+        *self = Announcement::from_row(&row);
+
+        Ok(())
+    }
+
+    async fn get(id: impl PrimaryKey, client: &Client) -> anyhow::Result<Option<Self>> {
+        let query = "SELECT * FROM announcements WHERE id = $1;";
+        let prepared = client.prepare(query).await?;
+        Ok(client
+            .query_opt(&prepared, &[&id])
+            .await?
+            .map(|e| Announcement::from_row(&e)))
+    }
+
+    async fn all(client: &Client) -> anyhow::Result<Vec<Self>> {
+        let query = "SELECT * FROM announcements;";
+        let prepared = client.prepare(query).await?;
+        let rows = client.query(&prepared, &[]).await?;
+        Ok(rows.iter().map(Announcement::from_row).collect::<Vec<_>>())
+    }
+
+    async fn delete(&self, client: &Client) -> anyhow::Result<()> {
+        let query = "DELETE FROM announcements WHERE id = $1;";
+        let prepared = client.prepare(query).await?;
+        client.execute(&prepared, &[&self.id]).await?;
+        Ok(())
+    }
+}
+
+impl Announcement {
+    pub async fn upsert(&self, client: &Client) -> anyhow::Result<Announcement> {
+        let query = "INSERT INTO announcements (id, announcement_type, content, created_by, created_at, last_modified_by, last_modified_at)
+            VALUES ($1, $2, $3, $4, $5, $6, $7)
+            ON CONFLICT(id) 
+            DO UPDATE SET
+              announcement_type = EXCLUDED.announcement_type,
+              content = EXCLUDED.content,
+              last_modified_by = $6,
+              last_modified_at = $7
+            RETURNING *;";
+
+        let prepared = client.prepare(&query).await?;
+
+        let row = client
+            .query_one(
+                &prepared,
+                &[
+                    &self.id,
+                    &self.announcement_type,
+                    &self.content,
+                    &self.created_by,
+                    &self.created_at,
+                    &self.last_modified_by,
+                    &self.last_modified_at,
+                ],
+            )
+            .await?;
+
+        Ok(Announcement::from_row(&row))
+    }
+
+    pub async fn get_by_ids(
+        client: &Client,
+        ids: &Vec<DieselUlid>,
+    ) -> anyhow::Result<Vec<Announcement>> {
+        // Fast return if no ids are provided
+        if ids.is_empty() {
+            return Ok(Vec::new());
+        }
+
+        let query_one = "SELECT * FROM announcements WHERE announcements.id IN ";
+        let mut inserts = Vec::<&(dyn ToSql + Sync)>::new();
+        for id in ids {
+            inserts.push(id);
+        }
+        let query_insert = create_multi_query(&inserts);
+        let query = format!("{query_one}{query_insert};");
+        let prepared = client.prepare(&query).await?;
+        Ok(client
+            .query(&prepared, &inserts)
+            .await?
+            .iter()
+            .map(Announcement::from_row)
+            .collect())
+    }
+
+    pub async fn batch_delete(client: &Client, ids: &Vec<DieselUlid>) -> anyhow::Result<()> {
+        // Fast return if no ids are provided
+        if ids.is_empty() {
+            return Ok(());
+        }
+
+        let base_query = "DELETE FROM announcements WHERE announcements.id IN ";
+        let mut deletes = Vec::<&(dyn ToSql + Sync)>::new();
+        for id in ids {
+            deletes.push(id);
+        }
+        let included_deletions = create_multi_query(&deletes);
+        let query = format!("{base_query}{included_deletions};");
+        let prepared = client.prepare(&query).await?;
+
+        client.execute(&prepared, &deletes).await?;
+        Ok(())
+    }
+}

--- a/components/server/src/database/dsls/info_dsl.rs
+++ b/components/server/src/database/dsls/info_dsl.rs
@@ -85,7 +85,7 @@ impl Announcement {
               modified_at = $6
             RETURNING *;";
 
-        let prepared = client.prepare(&query).await?;
+        let prepared = client.prepare(query).await?;
 
         let row = client
             .query_one(

--- a/components/server/src/database/dsls/info_dsl.rs
+++ b/components/server/src/database/dsls/info_dsl.rs
@@ -12,16 +12,16 @@ pub struct Announcement {
     pub announcement_type: String,
     pub title: String,
     pub content: String,
-    pub created_by: DieselUlid,
+    pub created_by: String,
     pub created_at: NaiveDateTime,
-    pub last_modified_by: DieselUlid,
-    pub last_modified_at: NaiveDateTime,
+    pub modified_by: String,
+    pub modified_at: NaiveDateTime,
 }
 
 #[async_trait::async_trait]
 impl CrudDb for Announcement {
     async fn create(&mut self, client: &Client) -> anyhow::Result<()> {
-        let query = "INSERT INTO announcements (id, announcement_type, title, content, created_by, created_at, last_modified_by, last_modified_at)
+        let query = "INSERT INTO announcements (id, announcement_type, title, content, created_by, created_at, modified_by, modified_at)
             VALUES ($1, $2, $3, $4, $5, $6, $7, $8)
             RETURNING *;";
 
@@ -37,8 +37,8 @@ impl CrudDb for Announcement {
                     &self.content,
                     &self.created_by,
                     &self.created_at,
-                    &self.last_modified_by,
-                    &self.last_modified_at,
+                    &self.modified_by,
+                    &self.modified_at,
                 ],
             )
             .await?;
@@ -74,15 +74,15 @@ impl CrudDb for Announcement {
 
 impl Announcement {
     pub async fn upsert(&self, client: &Client) -> anyhow::Result<Announcement> {
-        let query = "INSERT INTO announcements (id, announcement_type, title, content, created_by, created_at, last_modified_by, last_modified_at)
+        let query = "INSERT INTO announcements (id, announcement_type, title, content, created_by, created_at, modified_by, modified_at)
             VALUES ($1, $2, $3, $4, $5, $6, $7, $8)
             ON CONFLICT(id) 
             DO UPDATE SET
               announcement_type = EXCLUDED.announcement_type,
               title = EXCLUDED.title,
               content = EXCLUDED.content,
-              last_modified_by = $7,
-              last_modified_at = $6
+              modified_by = $7,
+              modified_at = $6
             RETURNING *;";
 
         let prepared = client.prepare(&query).await?;
@@ -97,8 +97,8 @@ impl Announcement {
                     &self.content,
                     &self.created_by,
                     &self.created_at,
-                    &self.last_modified_by,
-                    &self.last_modified_at,
+                    &self.modified_by,
+                    &self.modified_at,
                 ],
             )
             .await?;

--- a/components/server/src/database/dsls/info_dsl.rs
+++ b/components/server/src/database/dsls/info_dsl.rs
@@ -10,6 +10,7 @@ use tokio_postgres::Client;
 pub struct Announcement {
     pub id: DieselUlid,
     pub announcement_type: String,
+    pub title: String,
     pub content: String,
     pub created_by: DieselUlid,
     pub created_at: NaiveDateTime,
@@ -20,8 +21,8 @@ pub struct Announcement {
 #[async_trait::async_trait]
 impl CrudDb for Announcement {
     async fn create(&mut self, client: &Client) -> anyhow::Result<()> {
-        let query = "INSERT INTO announcements (id, announcement_type, content, created_by, created_at, last_modified_by, last_modified_at)
-            VALUES ($1, $2, $3, $4, $5, $6, $7)
+        let query = "INSERT INTO announcements (id, announcement_type, title, content, created_by, created_at, last_modified_by, last_modified_at)
+            VALUES ($1, $2, $3, $4, $5, $6, $7, $8)
             RETURNING *;";
 
         let prepared = client.prepare(query).await?;
@@ -32,6 +33,7 @@ impl CrudDb for Announcement {
                 &[
                     &self.id,
                     &self.announcement_type,
+                    &self.title,
                     &self.content,
                     &self.created_by,
                     &self.created_at,
@@ -72,14 +74,15 @@ impl CrudDb for Announcement {
 
 impl Announcement {
     pub async fn upsert(&self, client: &Client) -> anyhow::Result<Announcement> {
-        let query = "INSERT INTO announcements (id, announcement_type, content, created_by, created_at, last_modified_by, last_modified_at)
-            VALUES ($1, $2, $3, $4, $5, $6, $7)
+        let query = "INSERT INTO announcements (id, announcement_type, title, content, created_by, created_at, last_modified_by, last_modified_at)
+            VALUES ($1, $2, $3, $4, $5, $6, $7, $8)
             ON CONFLICT(id) 
             DO UPDATE SET
               announcement_type = EXCLUDED.announcement_type,
+              title = EXCLUDED.title,
               content = EXCLUDED.content,
-              last_modified_by = $6,
-              last_modified_at = $7
+              last_modified_by = $7,
+              last_modified_at = $6
             RETURNING *;";
 
         let prepared = client.prepare(&query).await?;
@@ -90,6 +93,7 @@ impl Announcement {
                 &[
                     &self.id,
                     &self.announcement_type,
+                    &self.title,
                     &self.content,
                     &self.created_by,
                     &self.created_at,

--- a/components/server/src/database/dsls/info_dsl.rs
+++ b/components/server/src/database/dsls/info_dsl.rs
@@ -1,16 +1,20 @@
 use crate::database::crud::{CrudDb, PrimaryKey};
 use crate::utils::database_utils::create_multi_query;
+use aruna_rust_api::api::storage::models::v2::PageRequest;
 use chrono::NaiveDateTime;
 use diesel_ulid::DieselUlid;
 use postgres_from_row::FromRow;
 use postgres_types::ToSql;
+use std::str::FromStr;
 use tokio_postgres::Client;
 
-#[derive(FromRow, Debug, Clone)]
+#[derive(FromRow, Debug, Clone, PartialEq, Eq)]
 pub struct Announcement {
     pub id: DieselUlid,
     pub announcement_type: String,
     pub title: String,
+    pub teaser: String,
+    pub image_url: String,
     pub content: String,
     pub created_by: String,
     pub created_at: NaiveDateTime,
@@ -21,8 +25,9 @@ pub struct Announcement {
 #[async_trait::async_trait]
 impl CrudDb for Announcement {
     async fn create(&mut self, client: &Client) -> anyhow::Result<()> {
-        let query = "INSERT INTO announcements (id, announcement_type, title, content, created_by, created_at, modified_by, modified_at)
-            VALUES ($1, $2, $3, $4, $5, $6, $7, $8)
+        let query = "INSERT INTO announcements 
+            (id, announcement_type, title, teaser, image_url, content, created_by, created_at, modified_by, modified_at)
+            VALUES ($1, $2, $3, $4, $5, $6, $7, $8, $9, $10)
             RETURNING *;";
 
         let prepared = client.prepare(query).await?;
@@ -34,6 +39,8 @@ impl CrudDb for Announcement {
                     &self.id,
                     &self.announcement_type,
                     &self.title,
+                    &self.teaser,
+                    &self.image_url,
                     &self.content,
                     &self.created_by,
                     &self.created_at,
@@ -44,7 +51,6 @@ impl CrudDb for Announcement {
             .await?;
 
         *self = Announcement::from_row(&row);
-
         Ok(())
     }
 
@@ -52,13 +58,13 @@ impl CrudDb for Announcement {
         let query = "SELECT * FROM announcements WHERE id = $1;";
         let prepared = client.prepare(query).await?;
         Ok(client
-            .query_opt(&prepared, &[&id])
+            .query_opt(&prepared, &[&&id])
             .await?
             .map(|e| Announcement::from_row(&e)))
     }
 
     async fn all(client: &Client) -> anyhow::Result<Vec<Self>> {
-        let query = "SELECT * FROM announcements;";
+        let query = "SELECT * FROM announcements ORDER BY created_at;";
         let prepared = client.prepare(query).await?;
         let rows = client.query(&prepared, &[]).await?;
         Ok(rows.iter().map(Announcement::from_row).collect::<Vec<_>>())
@@ -74,15 +80,18 @@ impl CrudDb for Announcement {
 
 impl Announcement {
     pub async fn upsert(&self, client: &Client) -> anyhow::Result<Announcement> {
-        let query = "INSERT INTO announcements (id, announcement_type, title, content, created_by, created_at, modified_by, modified_at)
-            VALUES ($1, $2, $3, $4, $5, $6, $7, $8)
+        let query = "INSERT INTO announcements 
+              (id, announcement_type, title, teaser, image_url, content, created_by, created_at, modified_by, modified_at)
+            VALUES ($1, $2, $3, $4, $5, $6, $7, $8, $9, $10)
             ON CONFLICT(id) 
             DO UPDATE SET
               announcement_type = EXCLUDED.announcement_type,
               title = EXCLUDED.title,
+              teaser = EXCLUDED.teaser,
+              image_url = EXCLUDED.image_url,
               content = EXCLUDED.content,
-              modified_by = $7,
-              modified_at = $6
+              modified_by = $9,
+              modified_at = $10
             RETURNING *;";
 
         let prepared = client.prepare(query).await?;
@@ -94,6 +103,8 @@ impl Announcement {
                     &self.id,
                     &self.announcement_type,
                     &self.title,
+                    &self.teaser,
+                    &self.image_url,
                     &self.content,
                     &self.created_by,
                     &self.created_at,
@@ -106,29 +117,159 @@ impl Announcement {
         Ok(Announcement::from_row(&row))
     }
 
+    pub async fn all_paginated(
+        client: &Client,
+        page: Option<PageRequest>,
+    ) -> anyhow::Result<Vec<Announcement>> {
+        let mut query = "SELECT * FROM announcements ".to_string();
+        let mut inserts = Vec::<&(dyn ToSql + Sync)>::new();
+
+        //Note: This is the verbose version as tokio_postgres query params are not std::marker::send
+        let rows = if let Some(page) = page {
+            if let Ok(start_after) = DieselUlid::from_str(&page.start_after) {
+                inserts.push(&start_after);
+                query.push_str(&format!("WHERE id > ${} ", inserts.len()));
+
+                if page.page_size > 0 {
+                    inserts.push(&page.page_size);
+                    query.push_str(&format!(" ORDER BY created_at LIMIT ${};", inserts.len()));
+                } else {
+                    query.push_str(" ORDER BY created_at;");
+                }
+
+                let prepared = client.prepare(&query).await?;
+                client.query(&prepared, &inserts).await?
+            } else {
+                if page.page_size > 0 {
+                    inserts.push(&page.page_size);
+                    query.push_str(&format!(" ORDER BY created_at LIMIT ${};", inserts.len()));
+                } else {
+                    query.push_str(" ORDER BY created_at;");
+                }
+
+                let prepared = client.prepare(&query).await?;
+                client.query(&prepared, &inserts).await?
+            }
+        } else {
+            query.push_str(" ORDER BY created_at;");
+            let prepared = client.prepare(&query).await?;
+            client.query(&prepared, &inserts).await?
+        };
+
+        Ok(rows.iter().map(Announcement::from_row).collect::<Vec<_>>())
+    }
+
     pub async fn get_by_ids(
         client: &Client,
         ids: &Vec<DieselUlid>,
+        page: Option<PageRequest>,
     ) -> anyhow::Result<Vec<Announcement>> {
         // Fast return if no ids are provided
         if ids.is_empty() {
             return Ok(Vec::new());
         }
 
-        let query_one = "SELECT * FROM announcements WHERE announcements.id IN ";
+        // Prepare and execute query
+        let mut query = "SELECT * FROM announcements WHERE id IN ".to_string();
         let mut inserts = Vec::<&(dyn ToSql + Sync)>::new();
         for id in ids {
             inserts.push(id);
         }
-        let query_insert = create_multi_query(&inserts);
-        let query = format!("{query_one}{query_insert};");
+        query.push_str(&create_multi_query(&inserts));
+
+        //Note: This is the verbose version as tokio_postgres query params are not std::marker::send
+        let rows = if let Some(page) = page {
+            if let Ok(start_after) = DieselUlid::from_str(&page.start_after) {
+                inserts.push(&start_after);
+                query.push_str(&format!(" AND id > ${}", inserts.len()));
+
+                if page.page_size > 0 {
+                    inserts.push(&page.page_size);
+                    query.push_str(&format!(" ORDER BY created_at LIMIT ${};", inserts.len()));
+                } else {
+                    query.push_str(" ORDER BY created_at;");
+                }
+
+                let prepared = client.prepare(&query).await?;
+                client.query(&prepared, &inserts).await?
+            } else {
+                if page.page_size > 0 {
+                    inserts.push(&page.page_size);
+                    query.push_str(&format!(" ORDER BY created_at LIMIT ${};", inserts.len()));
+                } else {
+                    query.push_str(" ORDER BY created_at;");
+                }
+
+                let prepared = client.prepare(&query).await?;
+                client.query(&prepared, &inserts).await?
+            }
+        } else {
+            query.push_str(" ORDER BY created_at;");
+            let prepared = client.prepare(&query).await?;
+            client.query(&prepared, &inserts).await?
+        };
+
+        /* Could be as compact as this
+        let (query, params) = SelectQueryBuilder::new_with_table("announcements")
+            .with_id_filter(ids)
+            .with_pagination_opt(page)
+            .build();
+
         let prepared = client.prepare(&query).await?;
-        Ok(client
-            .query(&prepared, &inserts)
-            .await?
-            .iter()
-            .map(Announcement::from_row)
-            .collect())
+        let param_slice = &params.iter().map(|x| x.as_ref()).collect::<Vec<_>>().as_slice();
+        let rows = client.query(&prepared, &param_slice).await?
+        */
+
+        Ok(rows.iter().map(Announcement::from_row).collect())
+    }
+
+    pub async fn get_by_type(
+        client: &Client,
+        announcement_type: String,
+        page: Option<PageRequest>,
+    ) -> anyhow::Result<Vec<Announcement>> {
+        // Fast return if no type is provided
+        if announcement_type.is_empty() {
+            return Ok(Vec::new());
+        }
+
+        // Prepare and execute query
+        let mut query = "SELECT * FROM announcements WHERE announcement_type = $1".to_string();
+        let mut params: Vec<&(dyn ToSql + Sync)> = vec![&announcement_type];
+
+        //Note: This is the verbose version as tokio_postgres query params are not std::marker::send
+        let rows = if let Some(page) = page {
+            if let Ok(start_after) = DieselUlid::from_str(&page.start_after) {
+                params.push(&start_after);
+                query.push_str(&format!(" AND id > ${}", params.len()));
+
+                if page.page_size > 0 {
+                    params.push(&page.page_size);
+                    query.push_str(&format!(" ORDER BY created_at LIMIT ${};", params.len()));
+                } else {
+                    query.push_str(" ORDER BY created_at;");
+                }
+
+                let prepared = client.prepare(&query).await?;
+                client.query(&prepared, &params).await?
+            } else {
+                if page.page_size > 0 {
+                    params.push(&page.page_size);
+                    query.push_str(&format!(" ORDER BY created_at LIMIT ${};", params.len()));
+                } else {
+                    query.push_str(" ORDER BY created_at;");
+                }
+
+                let prepared = client.prepare(&query).await?;
+                client.query(&prepared, &params).await?
+            }
+        } else {
+            query.push_str(" ORDER BY created_at;");
+            let prepared = client.prepare(&query).await?;
+            client.query(&prepared, &params).await?
+        };
+
+        Ok(rows.iter().map(Announcement::from_row).collect::<Vec<_>>())
     }
 
     pub async fn batch_delete(client: &Client, ids: &Vec<DieselUlid>) -> anyhow::Result<()> {

--- a/components/server/src/database/dsls/mod.rs
+++ b/components/server/src/database/dsls/mod.rs
@@ -2,6 +2,7 @@ pub mod endpoint_dsl;
 pub mod external_user_id_dsl;
 pub mod hook_dsl;
 pub mod identity_provider_dsl;
+pub mod info_dsl;
 pub mod internal_relation_dsl;
 pub mod license_dsl;
 pub mod notification_dsl;

--- a/components/server/src/database/schema.sql
+++ b/components/server/src/database/schema.sql
@@ -303,12 +303,13 @@ CREATE TABLE IF NOT EXISTS rule_bindings (
 CREATE TABLE IF NOT EXISTS announcements (
     id UUID PRIMARY KEY NOT NULL,
     announcement_type VARCHAR(128) NOT NULL,
+    title text NOT NULL,
     content text NOT NULL,
     created_by UUID REFERENCES users(id) NOT NULL,
     created_at TIMESTAMP NOT NULL DEFAULT NOW(),
     last_modified_by UUID REFERENCES users(id) NOT NULL,
     last_modified_at TIMESTAMP NOT NULL DEFAULT NOW(),
-    CONSTRAINT chk_announcement_type CHECK (announcement_type IN ('RELEASE', 'MAINTENANCE', 'UPDATE', 'MISC'))
+    CONSTRAINT chk_announcement_type CHECK (announcement_type IN ('MISC', 'RELEASE', 'UPDATE', 'MAINTENANCE'))
 );
 
 -- Insert predefined relation types

--- a/components/server/src/database/schema.sql
+++ b/components/server/src/database/schema.sql
@@ -306,6 +306,7 @@ CREATE TABLE IF NOT EXISTS announcements (
     content text NOT NULL,
     created_by UUID REFERENCES users(id) NOT NULL,
     created_at TIMESTAMP NOT NULL DEFAULT NOW(),
+    last_modified_by UUID REFERENCES users(id) NOT NULL,
     last_modified_at TIMESTAMP NOT NULL DEFAULT NOW(),
     CONSTRAINT chk_announcement_type CHECK (announcement_type IN ('RELEASE', 'MAINTENANCE', 'UPDATE', 'MISC'))
 );

--- a/components/server/src/database/schema.sql
+++ b/components/server/src/database/schema.sql
@@ -303,13 +303,15 @@ CREATE TABLE IF NOT EXISTS rule_bindings (
 CREATE TABLE IF NOT EXISTS announcements (
     id UUID PRIMARY KEY NOT NULL,
     announcement_type VARCHAR(128) NOT NULL,
-    title text NOT NULL,
+    title VARCHAR(256) NOT NULL,
+    teaser VARCHAR(2048) NOT NULL DEFAULT '',
+    image_url VARCHAR(4096) NOT NULL DEFAULT '', -- Should be sufficient?
     content text NOT NULL,
     created_by VARCHAR(128) NOT NULL,
     created_at TIMESTAMP NOT NULL DEFAULT NOW(),
     modified_by VARCHAR(128) NOT NULL,
     modified_at TIMESTAMP NOT NULL DEFAULT NOW(),
-    CONSTRAINT chk_announcement_type CHECK (announcement_type IN ('MISC', 'RELEASE', 'UPDATE', 'MAINTENANCE'))
+    CONSTRAINT chk_announcement_type CHECK (announcement_type IN ('ORGA', 'RELEASE', 'UPDATE', 'MAINTENANCE', 'BLOG'))
 );
 
 -- Insert predefined relation types

--- a/components/server/src/database/schema.sql
+++ b/components/server/src/database/schema.sql
@@ -305,10 +305,10 @@ CREATE TABLE IF NOT EXISTS announcements (
     announcement_type VARCHAR(128) NOT NULL,
     title text NOT NULL,
     content text NOT NULL,
-    created_by UUID REFERENCES users(id) NOT NULL,
+    created_by VARCHAR(128) NOT NULL,
     created_at TIMESTAMP NOT NULL DEFAULT NOW(),
-    last_modified_by UUID REFERENCES users(id) NOT NULL,
-    last_modified_at TIMESTAMP NOT NULL DEFAULT NOW(),
+    modified_by VARCHAR(128) NOT NULL,
+    modified_at TIMESTAMP NOT NULL DEFAULT NOW(),
     CONSTRAINT chk_announcement_type CHECK (announcement_type IN ('MISC', 'RELEASE', 'UPDATE', 'MAINTENANCE'))
 );
 

--- a/components/server/src/database/schema.sql
+++ b/components/server/src/database/schema.sql
@@ -299,6 +299,17 @@ CREATE TABLE IF NOT EXISTS rule_bindings (
     PRIMARY KEY(rule_id, origin_id, object_id)
 );
 
+/* ----- Announcements ------------------------------------- */
+CREATE TABLE IF NOT EXISTS announcements (
+    id UUID PRIMARY KEY NOT NULL,
+    announcement_type VARCHAR(128) NOT NULL,
+    content text NOT NULL,
+    created_by UUID REFERENCES users(id) NOT NULL,
+    created_at TIMESTAMP NOT NULL DEFAULT NOW(),
+    last_modified_at TIMESTAMP NOT NULL DEFAULT NOW(),
+    CONSTRAINT chk_announcement_type CHECK (announcement_type IN ('RELEASE', 'MAINTENANCE', 'UPDATE', 'MISC'))
+);
+
 -- Insert predefined relation types
 INSERT INTO relation_types (relation_name) VALUES ('BELONGS_TO'), ('VERSION'), ('METADATA'), ('ORIGIN'), ('POLICY'), ('DELETED') ON CONFLICT (relation_name) DO NOTHING;
 -- Create partial unique index for BELONGS_TO relations only

--- a/components/server/src/grpc/users.rs
+++ b/components/server/src/grpc/users.rs
@@ -37,6 +37,7 @@ use aruna_rust_api::api::storage::services::v2::{
     UpdateUserDisplayNameResponse, UpdateUserEmailRequest, UpdateUserEmailResponse,
 };
 use diesel_ulid::DieselUlid;
+use log::error;
 use std::str::FromStr;
 use std::sync::Arc;
 use tonic::{Request, Response, Status};
@@ -78,7 +79,7 @@ impl UserService for UserServiceImpl {
 
         // Try to send mail to recently registered users email address
         if let Some(mailclient) = self.mailclient.as_ref() {
-            let _ = mailclient.send_message(
+            if let Err(err) = mailclient.send_message(
                 &user.email,
                 format!("Dear {},
 We are excited to inform you that your registration with Aruna has been successfully completed.\n
@@ -87,7 +88,9 @@ Thank you for joining us, and we look forward to supporting you on your journey!
 With kind regards,
 the Aruna team", user.display_name),
                 "Welcome to Aruna - Registration Successful",
-            );
+            ) {
+                error!("{:#?}", err);
+            }
         }
 
         return_with_log!(RegisterUserResponse {
@@ -144,7 +147,7 @@ the Aruna team", user.display_name),
 
         // Try to send mail to recently activated users email address
         if let Some(mailclient) = self.mailclient.as_ref() {
-            let _ = mailclient.send_message(
+            if let Err(err) = mailclient.send_message(
                 &user.email,
                 format!("Dear {},
 your Aruna user account has been activated.\n
@@ -152,7 +155,9 @@ Again, if you have any questions or need assistance, feel free to contact us via
 Kind regards,
 the Aruna team", user.display_name),
                 "[ARUNA] User activated",
-            );
+            ) {
+                error!("{:#?}", err); 
+            }
         }
 
         return_with_log!(ActivateUserResponse {});

--- a/components/server/src/middlelayer/announcements_db_handler.rs
+++ b/components/server/src/middlelayer/announcements_db_handler.rs
@@ -19,7 +19,7 @@ impl DatabaseHandler {
         // Create database client
         let client = self.database.get_client().await?;
 
-        Ok(if request.announcement_ids.len() > 0 {
+        Ok(if !request.announcement_ids.is_empty() {
             // Parse the ids
             let mapped_ids: Result<Vec<_>, _> = request
                 .announcement_ids

--- a/components/server/src/middlelayer/announcements_db_handler.rs
+++ b/components/server/src/middlelayer/announcements_db_handler.rs
@@ -1,0 +1,83 @@
+use crate::database::crud::CrudDb;
+use crate::database::dsls::info_dsl::Announcement as DbAnnouncement;
+use crate::middlelayer::db_handler::DatabaseHandler;
+use anyhow::anyhow;
+use anyhow::Result;
+use aruna_rust_api::api::storage::services::v2::{Announcement, SetAnnouncementsRequest};
+use diesel_ulid::DieselUlid;
+use itertools::Itertools;
+use std::str::FromStr;
+
+impl DatabaseHandler {
+    pub async fn get_announcements(&self) -> Result<Vec<Announcement>> {
+        let client = self.database.get_client().await?;
+        return Ok(DbAnnouncement::all(&client)
+            .await?
+            .into_iter()
+            .map(|a| a.into())
+            .collect_vec());
+    }
+
+    pub async fn get_announcement(&self, id: DieselUlid) -> Result<Announcement> {
+        let client = self.database.get_client().await?;
+
+        let announcement = DbAnnouncement::get(id, &client)
+            .await?
+            .ok_or_else(|| anyhow!("Announcement not found"))?;
+
+        return Ok(announcement.try_into()?);
+    }
+
+    pub async fn set_announcements(
+        &self,
+        user_id: DieselUlid,
+        request: SetAnnouncementsRequest,
+    ) -> Result<Vec<Announcement>> {
+        let mut client = self.database.get_client().await?;
+        let transaction = client.transaction().await?;
+        let transaction_client = transaction.client(); // Necessary?
+
+        // Upserts
+        let user_name = self
+            .cache
+            .get_user(&user_id)
+            .ok_or_else(|| anyhow!("User not found"))?
+            .display_name;
+        let mut upserted = vec![];
+        for announcement in request.announcements_upsert {
+            let mut db_announcement: DbAnnouncement = announcement.try_into()?;
+
+            // Set display name/id of request user if no creator/modifier is provided
+            if db_announcement.created_by.is_empty() {
+                db_announcement.created_by = if user_name.is_empty() {
+                    user_id.to_string()
+                } else {
+                    user_name.to_string()
+                };
+            }
+            if db_announcement.modified_by.is_empty() {
+                db_announcement.modified_by = if user_name.is_empty() {
+                    user_id.to_string()
+                } else {
+                    user_name.to_string()
+                };
+            }
+
+            upserted.push(db_announcement.upsert(&transaction_client).await?);
+        }
+
+        // Deletions
+        if !request.announcements_delete.is_empty() {
+            let deletions: Result<Vec<_>, _> = request
+                .announcements_delete
+                .into_iter()
+                .map(|id| DieselUlid::from_str(&id))
+                .collect();
+            DbAnnouncement::batch_delete(&transaction_client, &deletions?).await?;
+        }
+
+        transaction.commit().await?;
+
+        return Ok(upserted.into_iter().map(|u| u.into()).collect_vec());
+    }
+}

--- a/components/server/src/middlelayer/announcements_db_handler.rs
+++ b/components/server/src/middlelayer/announcements_db_handler.rs
@@ -11,11 +11,11 @@ use std::str::FromStr;
 impl DatabaseHandler {
     pub async fn get_announcements(&self) -> Result<Vec<Announcement>> {
         let client = self.database.get_client().await?;
-        return Ok(DbAnnouncement::all(&client)
+        Ok(DbAnnouncement::all(&client)
             .await?
             .into_iter()
             .map(|a| a.into())
-            .collect_vec());
+            .collect_vec())
     }
 
     pub async fn get_announcement(&self, id: DieselUlid) -> Result<Announcement> {
@@ -25,7 +25,7 @@ impl DatabaseHandler {
             .await?
             .ok_or_else(|| anyhow!("Announcement not found"))?;
 
-        return Ok(announcement.try_into()?);
+        Ok(announcement.try_into()?)
     }
 
     pub async fn set_announcements(
@@ -63,7 +63,7 @@ impl DatabaseHandler {
                 };
             }
 
-            upserted.push(db_announcement.upsert(&transaction_client).await?);
+            upserted.push(db_announcement.upsert(transaction_client).await?);
         }
 
         // Deletions
@@ -73,11 +73,11 @@ impl DatabaseHandler {
                 .into_iter()
                 .map(|id| DieselUlid::from_str(&id))
                 .collect();
-            DbAnnouncement::batch_delete(&transaction_client, &deletions?).await?;
+            DbAnnouncement::batch_delete(transaction_client, &deletions?).await?;
         }
 
         transaction.commit().await?;
 
-        return Ok(upserted.into_iter().map(|u| u.into()).collect_vec());
+        Ok(upserted.into_iter().map(|u| u.into()).collect_vec())
     }
 }

--- a/components/server/src/middlelayer/mod.rs
+++ b/components/server/src/middlelayer/mod.rs
@@ -1,5 +1,4 @@
 pub mod announcements_db_handler;
-
 pub mod clone_db_handler;
 pub mod clone_request_types;
 pub mod create_db_handler;

--- a/components/server/src/middlelayer/mod.rs
+++ b/components/server/src/middlelayer/mod.rs
@@ -1,3 +1,5 @@
+pub mod announcements_db_handler;
+
 pub mod clone_db_handler;
 pub mod clone_request_types;
 pub mod create_db_handler;

--- a/components/server/src/utils/conversions/announcements.rs
+++ b/components/server/src/utils/conversions/announcements.rs
@@ -11,7 +11,7 @@ fn string_to_announcement_type(input: String) -> AnnouncementType {
         "RELEASE" => return AnnouncementType::Release,
         "UPDATE" => return AnnouncementType::Update,
         "MAINTENANCE" => return AnnouncementType::Maintenance,
-        _ => return AnnouncementType::Unspecified
+        _ => return AnnouncementType::Unspecified,
     }
 }
 

--- a/components/server/src/utils/conversions/announcements.rs
+++ b/components/server/src/utils/conversions/announcements.rs
@@ -32,10 +32,10 @@ impl From<DbAnnouncement> for Announcement {
             announcement_type: string_to_announcement_type(value.announcement_type) as i32,
             title: value.title,
             content: value.content,
-            created_by: value.created_by.to_string(),
+            created_by: value.created_by,
             created_at: Some(value.created_at.into()),
-            modified_by: value.last_modified_by.to_string(),
-            modified_at: Some(value.last_modified_at.into()),
+            modified_by: value.modified_by,
+            modified_at: Some(value.modified_at.into()),
         }
     }
 }
@@ -49,7 +49,7 @@ impl TryFrom<Announcement> for DbAnnouncement {
             announcement_type: announcement_type_to_string(value.announcement_type())?,
             title: value.title,
             content: value.content,
-            created_by: Default::default(), // Has to be replaced afterward
+            created_by: value.created_by, // Will be replaced afterward if empty
             created_at: if let Some(timestamp) = value.created_at {
                 DateTime::from_timestamp(timestamp.seconds, timestamp.nanos.try_into()?)
                     .map(|e| e.naive_utc())
@@ -57,8 +57,8 @@ impl TryFrom<Announcement> for DbAnnouncement {
             } else {
                 Utc::now().naive_utc()
             },
-            last_modified_by: Default::default(), // Has to be replaced afterward
-            last_modified_at: if let Some(timestamp) = value.modified_at {
+            modified_by: value.modified_by, // Will be replaced afterward if empty
+            modified_at: if let Some(timestamp) = value.modified_at {
                 DateTime::from_timestamp(timestamp.seconds, timestamp.nanos.try_into()?)
                     .map(|e| e.naive_utc())
                     .unwrap_or_default()

--- a/components/server/src/utils/conversions/announcements.rs
+++ b/components/server/src/utils/conversions/announcements.rs
@@ -45,7 +45,11 @@ impl TryFrom<Announcement> for DbAnnouncement {
 
     fn try_from(value: Announcement) -> Result<Self, Self::Error> {
         Ok(DbAnnouncement {
-            id: DieselUlid::from_str(&value.id)?,
+            id: if value.id.is_empty() {
+                DieselUlid::generate()
+            } else {
+                DieselUlid::from_str(&value.id)?
+            },
             announcement_type: announcement_type_to_string(value.announcement_type())?,
             title: value.title,
             content: value.content,

--- a/components/server/src/utils/conversions/announcements.rs
+++ b/components/server/src/utils/conversions/announcements.rs
@@ -1,0 +1,70 @@
+use crate::database::dsls::info_dsl::Announcement as DbAnnouncement;
+use anyhow::{bail, Result};
+use aruna_rust_api::api::storage::services::v2::{Announcement, AnnouncementType};
+use chrono::{DateTime, Utc};
+use diesel_ulid::DieselUlid;
+use std::str::FromStr;
+
+fn string_to_announcement_type(input: String) -> AnnouncementType {
+    match input.as_str() {
+        "MISC" => return AnnouncementType::Misc,
+        "RELEASE" => return AnnouncementType::Release,
+        "UPDATE" => return AnnouncementType::Update,
+        "MAINTENANCE" => return AnnouncementType::Maintenance,
+        _ => return AnnouncementType::Unspecified
+    }
+}
+
+fn announcement_type_to_string(input: AnnouncementType) -> Result<String> {
+    Ok(match input {
+        AnnouncementType::Unspecified => bail!("Unspecified Announcement Type"),
+        AnnouncementType::Misc => "MISC".to_string(),
+        AnnouncementType::Release => "RELEASE".to_string(),
+        AnnouncementType::Update => "UPDATE".to_string(),
+        AnnouncementType::Maintenance => "MAINTENANCE".to_string(),
+    })
+}
+
+impl From<DbAnnouncement> for Announcement {
+    fn from(value: DbAnnouncement) -> Self {
+        Announcement {
+            id: value.id.to_string(),
+            announcement_type: string_to_announcement_type(value.announcement_type) as i32,
+            title: value.title,
+            content: value.content,
+            created_by: value.created_by.to_string(),
+            created_at: Some(value.created_at.into()),
+            modified_by: value.last_modified_by.to_string(),
+            modified_at: Some(value.last_modified_at.into()),
+        }
+    }
+}
+
+impl TryFrom<Announcement> for DbAnnouncement {
+    type Error = anyhow::Error;
+
+    fn try_from(value: Announcement) -> Result<Self, Self::Error> {
+        Ok(DbAnnouncement {
+            id: DieselUlid::from_str(&value.id)?,
+            announcement_type: announcement_type_to_string(value.announcement_type())?,
+            title: value.title,
+            content: value.content,
+            created_by: Default::default(), // Has to be replaced afterward
+            created_at: if let Some(timestamp) = value.created_at {
+                DateTime::from_timestamp(timestamp.seconds, timestamp.nanos.try_into()?)
+                    .map(|e| e.naive_utc())
+                    .unwrap_or_default()
+            } else {
+                Utc::now().naive_utc()
+            },
+            last_modified_by: Default::default(), // Has to be replaced afterward
+            last_modified_at: if let Some(timestamp) = value.modified_at {
+                DateTime::from_timestamp(timestamp.seconds, timestamp.nanos.try_into()?)
+                    .map(|e| e.naive_utc())
+                    .unwrap_or_default()
+            } else {
+                Utc::now().naive_utc()
+            },
+        })
+    }
+}

--- a/components/server/src/utils/conversions/announcements.rs
+++ b/components/server/src/utils/conversions/announcements.rs
@@ -7,11 +7,11 @@ use std::str::FromStr;
 
 fn string_to_announcement_type(input: String) -> AnnouncementType {
     match input.as_str() {
-        "MISC" => return AnnouncementType::Misc,
-        "RELEASE" => return AnnouncementType::Release,
-        "UPDATE" => return AnnouncementType::Update,
-        "MAINTENANCE" => return AnnouncementType::Maintenance,
-        _ => return AnnouncementType::Unspecified,
+        "MISC" => AnnouncementType::Misc,
+        "RELEASE" => AnnouncementType::Release,
+        "UPDATE" => AnnouncementType::Update,
+        "MAINTENANCE" => AnnouncementType::Maintenance,
+        _ => AnnouncementType::Unspecified,
     }
 }
 

--- a/components/server/src/utils/conversions/announcements.rs
+++ b/components/server/src/utils/conversions/announcements.rs
@@ -69,13 +69,16 @@ impl TryFrom<Announcement> for DbAnnouncement {
                 current_timestamp
             },
             modified_by: value.modified_by, // Will be replaced afterward if empty
-            modified_at: if let Some(timestamp) = value.modified_at {
+            modified_at: current_timestamp,
+            /*
+            if let Some(timestamp) = value.modified_at {
                 DateTime::from_timestamp(timestamp.seconds, timestamp.nanos.try_into()?)
                     .map(|e| e.naive_utc())
                     .unwrap_or_default()
             } else {
                 current_timestamp
             },
+            */
         })
     }
 }

--- a/components/server/src/utils/conversions/mod.rs
+++ b/components/server/src/utils/conversions/mod.rs
@@ -1,3 +1,4 @@
+mod announcements;
 pub mod endpoints;
 pub mod enums;
 pub mod hooks;

--- a/components/server/src/utils/conversions/mod.rs
+++ b/components/server/src/utils/conversions/mod.rs
@@ -1,4 +1,4 @@
-mod announcements;
+pub mod announcements;
 pub mod endpoints;
 pub mod enums;
 pub mod hooks;

--- a/components/server/tests/common/init.rs
+++ b/components/server/tests/common/init.rs
@@ -23,6 +23,7 @@ use std::sync::Arc;
 
 use super::test_utils::DEFAULT_ENDPOINT_ULID;
 
+#[allow(dead_code)]
 pub struct ServiceBlock {
     // Internal components
     pub db_conn: Arc<Database>,

--- a/components/server/tests/common/test_utils.rs
+++ b/components/server/tests/common/test_utils.rs
@@ -32,11 +32,17 @@ use aruna_server::{
 use dashmap::DashMap;
 use diesel_ulid::DieselUlid;
 use postgres_types::Json;
-use rand::{distributions::Alphanumeric, thread_rng, Rng};
+use rand::{distributions::Alphanumeric, seq::IteratorRandom, thread_rng, Rng};
 use tonic::{
     metadata::{AsciiMetadataKey, AsciiMetadataValue},
     Request,
 };
+
+#[allow(dead_code)]
+pub fn choose_and_remove(raw: &mut Vec<String>) -> Option<String> {
+    let i = (0..raw.len()).choose(&mut thread_rng())?;
+    Some(raw.swap_remove(i))
+}
 
 /* ----- Begin Testing Constants ---------- */
 #[allow(dead_code)]

--- a/components/server/tests/database/announcements.rs
+++ b/components/server/tests/database/announcements.rs
@@ -82,28 +82,6 @@ async fn get_test() {
         )
     }
 
-    /*
-    for idx in 1..10 {
-        announcements.push(
-            Announcement {
-                id: DieselUlid::generate(),
-                announcement_type: test_utils::choose(&mut types).unwrap().to_string(), //types.choose(&mut rand::thread_rng()).unwrap().to_string(),
-                title: format!("Announcement Title {idx}"),
-                teaser: format!("Announcement Teaser {idx}"),
-                image_url: format!("https://announcement_image_url/{idx}.webp"),
-                content: format!("Announcement Content {idx}"),
-                created_by: "The Aruna Team".to_string(),
-                created_at: chrono::Utc::now().naive_local(),
-                modified_by: "The Aruna Team".to_string(),
-                modified_at: chrono::Utc::now().naive_local(),
-            }
-            .upsert(client)
-            .await
-            .unwrap(),
-        )
-    }
-    */
-
     // Try get announcement with non existent id
     assert!(Announcement::get(DieselUlid::generate(), client)
         .await

--- a/components/server/tests/database/announcements.rs
+++ b/components/server/tests/database/announcements.rs
@@ -37,3 +37,51 @@ async fn create_test() {
     )
 }
 
+#[tokio::test]
+async fn upsert_test() {
+    let db = init::init_database().await;
+    let client = db.get_client().await.unwrap();
+    let client = client.client();
+
+    // Invalid announcement type
+    let mut ann = Announcement {
+        id: DieselUlid::generate(),
+        announcement_type: "ORGA".to_string(),
+        title: "Original Announcement Title".to_string(),
+        teaser: "Original Announcement Teaser".to_string(),
+        image_url: format!("https://announcement_image_url/example.webp"),
+        content: "Original Announcement Content".to_string(),
+        created_by: "The Aruna Team".to_string(),
+        created_at: chrono::Utc::now().naive_local(),
+        modified_by: "The Aruna Team".to_string(),
+        modified_at: chrono::Utc::now().naive_local(),
+    };
+    ann.create(client).await.unwrap();
+
+    // Try to set invalid and valid announcement type 
+    ann.announcement_type = "INVALID".to_string();
+    assert!(ann.create(client).await.is_err());
+    ann.announcement_type = "BLOG".to_string();
+
+    let type_updated = ann.upsert(client).await.unwrap();
+
+    assert_eq!(ann.id, type_updated.id);
+    assert_eq!(&type_updated.announcement_type, "BLOG");
+
+    // Update announcement title
+    ann.title = "Updated Announcement Title".to_string();
+    let title_updated = ann.upsert(client).await.unwrap();
+
+    assert_eq!(ann.id, title_updated.id);
+    assert_eq!(&title_updated.title, "Updated Announcement Title");
+
+    // Update announcement teaser and content together
+    ann.teaser = "Updated Announcement Teaser".to_string();
+    ann.content = "Updated Announcement Content".to_string();
+
+    let teaser_content_updated = ann.upsert(client).await.unwrap();
+
+    assert_eq!(ann.id, teaser_content_updated.id);
+    assert_eq!(&teaser_content_updated.teaser, "Updated Announcement Teaser");
+    assert_eq!(&teaser_content_updated.content, "Updated Announcement Content");
+}

--- a/components/server/tests/database/announcements.rs
+++ b/components/server/tests/database/announcements.rs
@@ -19,7 +19,7 @@ async fn create_test() {
         announcement_type: "INVALID".to_string(),
         title: "Announcement Title".to_string(),
         teaser: "Announcement Teaser".to_string(),
-        image_url: format!("https://announcement_image_url/dummy.webp"),
+        image_url: "https://announcement_image_url/dummy.webp".to_string(),
         content: "Announcement Content".to_string(),
         created_by: "The Aruna Team".to_string(),
         created_at: chrono::Utc::now().naive_local(),
@@ -90,11 +90,11 @@ async fn get_test() {
         .is_none());
 
     // Get any from the created announcements
-    let get_announcement = Announcement::get(announcements.get(0).unwrap().id, client)
+    let get_announcement = Announcement::get(announcements.first().unwrap().id, client)
         .await
         .unwrap()
         .unwrap();
-    assert_eq!(get_announcement, *announcements.get(0).unwrap());
+    assert_eq!(get_announcement, *announcements.first().unwrap());
 
     // Get all announcements (paginated)
     let all = Announcement::all(client).await.unwrap();
@@ -207,7 +207,7 @@ async fn upsert_test() {
         announcement_type: "ORGA".to_string(),
         title: "Original Announcement Title".to_string(),
         teaser: "Original Announcement Teaser".to_string(),
-        image_url: format!("https://announcement_image_url/example.webp"),
+        image_url: "https://announcement_image_url/example.webp".to_string(),
         content: "Original Announcement Content".to_string(),
         created_by: "The Aruna Team".to_string(),
         created_at: chrono::Utc::now().naive_local(),
@@ -258,7 +258,6 @@ async fn delete_test() {
 
     // Create some dummy announcements
     let ann_futures = (0..5)
-        .into_iter()
         .map(|_| async {
             Announcement {
                 id: DieselUlid::generate(),

--- a/components/server/tests/database/announcements.rs
+++ b/components/server/tests/database/announcements.rs
@@ -1,0 +1,39 @@
+use aruna_server::database::{crud::CrudDb, dsls::info_dsl::Announcement};
+use diesel_ulid::DieselUlid;
+use rand::seq::SliceRandom;
+use tokio_postgres::GenericClient;
+
+use crate::common::init;
+
+#[tokio::test]
+async fn create_test() {
+    let db = init::init_database().await;
+    let client = db.get_client().await.unwrap();
+    let client = client.client();
+
+    // Invalid announcement type
+    let mut ann = Announcement {
+        id: DieselUlid::generate(),
+        announcement_type: "INVALID".to_string(),
+        title: "Announcement Title".to_string(),
+        teaser: "Announcement Teaser".to_string(),
+        image_url: format!("https://announcement_image_url/dummy.webp"),
+        content: "Announcement Content".to_string(),
+        created_by: "The Aruna Team".to_string(),
+        created_at: chrono::Utc::now().naive_local(),
+        modified_by: "The Aruna Team".to_string(),
+        modified_at: chrono::Utc::now().naive_local(),
+    };
+    let res = ann.create(client).await;
+
+    assert!(res.is_err());
+
+    ann.announcement_type = "RELEASE".to_string();
+    ann.create(client).await.unwrap();
+
+    assert_eq!(
+        ann,
+        Announcement::get(ann.id, client).await.unwrap().unwrap()
+    )
+}
+

--- a/components/server/tests/database/mod.rs
+++ b/components/server/tests/database/mod.rs
@@ -1,3 +1,4 @@
+pub mod announcements;
 pub mod endpoints;
 pub mod hooks;
 pub mod licenses;

--- a/components/server/tests/grpc/info.rs
+++ b/components/server/tests/grpc/info.rs
@@ -1,0 +1,120 @@
+use aruna_rust_api::api::storage::services::v2::storage_status_service_server::StorageStatusService;
+use aruna_rust_api::api::storage::{
+    models::v2::AnnouncementType,
+    services::v2::{Announcement as ProtoAnnouncement, SetAnnouncementsRequest},
+};
+use itertools::Itertools;
+use tonic::Request;
+
+use crate::common::{
+    init::init_storage_status_service,
+    test_utils::{self, add_token},
+};
+
+#[tokio::test]
+async fn set_announcement() {
+    // Init StorageStatusService
+    let info_service = init_storage_status_service().await;
+
+    let mut inner_request = SetAnnouncementsRequest {
+        announcements_upsert: vec![
+            ProtoAnnouncement {
+                announcement_id: "".to_string(),
+                announcement_type: AnnouncementType::Release as i32,
+                title: "gRPC set_announcement(1)".to_string(),
+                teaser: "Some teaser".to_string(),
+                image_url: "".to_string(),
+                content: "".to_string(),
+                created_by: "The Aruna Team".to_string(),
+                created_at: None,
+                modified_by: "The Aruna Team".to_string(),
+                modified_at: None,
+            },
+            ProtoAnnouncement {
+                announcement_id: "".to_string(),
+                announcement_type: AnnouncementType::Blog as i32,
+                title: "gRPC set_announcement(2)".to_string(),
+                teaser: "Some teaser".to_string(),
+                image_url: "".to_string(),
+                content: "".to_string(),
+                created_by: "The Aruna Team".to_string(),
+                created_at: None,
+                modified_by: "The Aruna Team".to_string(),
+                modified_at: None,
+            },
+        ],
+        announcements_delete: vec![],
+    };
+
+    // Set announcements without token
+    let grpc_request = Request::new(inner_request.clone());
+    assert!(info_service.set_announcements(grpc_request).await.is_err());
+
+    // Set announcements with invalid token
+    let grpc_request = add_token(
+        Request::new(inner_request.clone()),
+        test_utils::INVALID_OIDC_TOKEN,
+    );
+    assert!(info_service.set_announcements(grpc_request).await.is_err());
+
+    // Set announcements without sufficient permissions
+    let grpc_request = add_token(
+        Request::new(inner_request.clone()),
+        test_utils::USER1_OIDC_TOKEN,
+    );
+    assert!(info_service.set_announcements(grpc_request).await.is_err());
+
+    // Set announcements
+    let grpc_request = add_token(
+        Request::new(inner_request.clone()),
+        test_utils::ADMIN_OIDC_TOKEN,
+    );
+    let inserted_announcements = info_service
+        .set_announcements(grpc_request)
+        .await
+        .unwrap()
+        .into_inner()
+        .announcements;
+
+    //TODO: Update announcements
+    let mut update_announcement = inserted_announcements.first().unwrap().clone();
+    update_announcement.announcement_type = AnnouncementType::Update as i32;
+    update_announcement.content = "Lorem Ipsum Dolor".to_string();
+    inner_request.announcements_upsert = vec![update_announcement];
+
+    let grpc_request = add_token(
+        Request::new(inner_request.clone()),
+        test_utils::ADMIN_OIDC_TOKEN,
+    );
+
+    let updated_announcements = info_service
+        .set_announcements(grpc_request)
+        .await
+        .unwrap()
+        .into_inner()
+        .announcements;
+
+    let original = inserted_announcements.first().unwrap();
+    let updated = updated_announcements.first().unwrap();
+
+    assert_eq!(original.announcement_id, updated.announcement_id);
+    assert_ne!(original.announcement_type, updated.announcement_type);
+    assert_ne!(original.content, updated.content);
+    assert_ne!(original.modified_at, updated.modified_at);
+
+    // Delete announcements
+    let delete_ids = inserted_announcements
+        .iter()
+        .map(|a| a.announcement_id.clone())
+        .collect_vec();
+    inner_request.announcements_upsert = vec![];
+    inner_request.announcements_delete = delete_ids;
+
+    let grpc_request = add_token(
+        Request::new(inner_request.clone()),
+        test_utils::ADMIN_OIDC_TOKEN,
+    );
+
+    info_service.set_announcements(grpc_request).await.unwrap();
+}
+

--- a/components/server/tests/grpc/info.rs
+++ b/components/server/tests/grpc/info.rs
@@ -1,11 +1,14 @@
 use aruna_rust_api::api::storage::services::v2::storage_status_service_server::StorageStatusService;
+use aruna_rust_api::api::storage::services::v2::GetAnnouncementRequest;
 use aruna_rust_api::api::storage::{
     models::v2::AnnouncementType,
     services::v2::{Announcement as ProtoAnnouncement, SetAnnouncementsRequest},
 };
+use diesel_ulid::DieselUlid;
 use itertools::Itertools;
 use tonic::Request;
 
+use crate::common::test_utils::ADMIN_OIDC_TOKEN;
 use crate::common::{
     init::init_storage_status_service,
     test_utils::{self, add_token},
@@ -118,3 +121,104 @@ async fn set_announcement() {
     info_service.set_announcements(grpc_request).await.unwrap();
 }
 
+#[tokio::test]
+async fn get_announcement() {
+    // Init StorageStatusService
+    let info_service = init_storage_status_service().await;
+
+    let set_request = SetAnnouncementsRequest {
+        announcements_upsert: vec![ProtoAnnouncement {
+            announcement_id: "".to_string(),
+            announcement_type: AnnouncementType::Blog as i32,
+            title: "gRPC get_announcement(1)".to_string(),
+            teaser: "Some teaser".to_string(),
+            image_url: "".to_string(),
+            content: "".to_string(),
+            created_by: "The Aruna Team".to_string(),
+            created_at: None,
+            modified_by: "The Aruna Team".to_string(),
+            modified_at: None,
+        }],
+        announcements_delete: vec![],
+    };
+
+    // Insert announcement
+    let grpc_request = add_token(Request::new(set_request), test_utils::ADMIN_OIDC_TOKEN);
+    let inserted_announcements = info_service
+        .set_announcements(grpc_request)
+        .await
+        .unwrap()
+        .into_inner()
+        .announcements;
+    let inserted_announcement = inserted_announcements.first().unwrap();
+
+    // Get non-existent announcement
+    let mut get_request = GetAnnouncementRequest {
+        announcement_id: DieselUlid::generate().to_string(),
+    };
+    let grpc_request = Request::new(get_request.clone());
+
+    assert!(info_service.get_announcement(grpc_request).await.is_err());
+
+    // Get announcement without token
+    get_request.announcement_id = inserted_announcement.announcement_id.to_string();
+    let grpc_request = Request::new(get_request.clone());
+
+    let get_announcement = info_service
+        .get_announcement(grpc_request)
+        .await
+        .unwrap()
+        .into_inner()
+        .announcement
+        .unwrap();
+
+    assert_eq!(inserted_announcement, &get_announcement);
+
+    // Get announcement with token
+    let get_request = GetAnnouncementRequest {
+        announcement_id: inserted_announcement.announcement_id.to_string(),
+    };
+    let grpc_request = add_token(Request::new(get_request.clone()), ADMIN_OIDC_TOKEN);
+
+    let get_announcement = info_service
+        .get_announcement(grpc_request)
+        .await
+        .unwrap()
+        .into_inner()
+        .announcement
+        .unwrap();
+
+    assert_eq!(inserted_announcement, &get_announcement);
+}
+
+#[tokio::test]
+async fn get_announcements() {
+    // Init StorageStatusService
+    let service = init_storage_status_service().await;
+
+    //TODO: Insert announcements
+
+    //TODO: Get all announcements
+
+    //TODO: Get all announcements paginated
+
+    //TODO: Get announcements by id
+
+    //TODO: Get announcements by id paginated
+
+    todo!();
+}
+
+#[tokio::test]
+async fn get_announcements_by_type() {
+    // Init StorageStatusService
+    let service = init_storage_status_service().await;
+
+    //TODO: Insert announcements
+
+    //TODO: Get announcements by type
+
+    //TODO: Get announcements by type paginated
+
+    todo!();
+}

--- a/components/server/tests/grpc/info.rs
+++ b/components/server/tests/grpc/info.rs
@@ -320,8 +320,8 @@ async fn get_announcements() {
 
     assert_eq!(id_announcements.len(), 2);
     assert_eq!(
-        inserted_announcements.get(0).unwrap(),
-        id_announcements.get(0).unwrap()
+        inserted_announcements.first().unwrap(),
+        id_announcements.first().unwrap()
     );
     assert_eq!(
         inserted_announcements.get(1).unwrap(),
@@ -481,7 +481,7 @@ async fn get_announcements_by_type() {
         .into_inner()
         .announcements;
 
-    assert!(type_announcements_page_02.len() >= 1);
+    assert!(!type_announcements_page_02.is_empty());
     for a in type_announcements_page_02 {
         assert_eq!(a.announcement_type(), AnnouncementType::Release)
     }

--- a/components/server/tests/grpc/info.rs
+++ b/components/server/tests/grpc/info.rs
@@ -434,11 +434,15 @@ async fn get_announcements_by_type() {
         .announcements;
 
     assert!(all_type_announcements.len() >= 3);
-    for a in &inserted_announcements {
+    for a in &inserted_announcements
+        .iter()
+        .filter(|a| a.announcement_type() == AnnouncementType::Orga)
+        .collect_vec()
+    {
         assert!(all_type_announcements.contains(a))
     }
     for a in all_type_announcements {
-        assert_eq!(a.announcement_type(), AnnouncementType::Orga)
+        assert_eq!(a.announcement_type(), AnnouncementType::Orga);
     }
 
     //TODO: Get announcements by type paginated
@@ -458,9 +462,6 @@ async fn get_announcements_by_type() {
         .announcements;
 
     assert_eq!(type_announcements_page_01.len(), 2);
-    for a in &inserted_announcements {
-        assert!(type_announcements_page_01.contains(a))
-    }
     for a in &type_announcements_page_01 {
         assert_eq!(a.announcement_type(), AnnouncementType::Release)
     }
@@ -481,9 +482,6 @@ async fn get_announcements_by_type() {
         .announcements;
 
     assert!(type_announcements_page_02.len() >= 1);
-    for a in &inserted_announcements {
-        assert!(type_announcements_page_02.contains(a))
-    }
     for a in type_announcements_page_02 {
         assert_eq!(a.announcement_type(), AnnouncementType::Release)
     }

--- a/components/server/tests/grpc/mod.rs
+++ b/components/server/tests/grpc/mod.rs
@@ -2,6 +2,7 @@ mod authorization;
 mod collection;
 mod dataset;
 mod endpoint;
+mod info;
 mod licenses;
 mod project;
 mod search;

--- a/components/server/tests/middlelayer/announcements.rs
+++ b/components/server/tests/middlelayer/announcements.rs
@@ -28,7 +28,7 @@ async fn get_announcement() {
         announcement_type: "RELEASE".to_string(),
         title: "Announcement Title".to_string(),
         teaser: "Announcement Teaser".to_string(),
-        image_url: format!("https://announcement_image_url/dummy.webp"),
+        image_url: "https://announcement_image_url/dummy.webp".to_string(),
         content: "Announcement Content".to_string(),
         created_by: "The Aruna Team".to_string(),
         created_at: chrono::Utc::now().naive_local(),
@@ -48,7 +48,7 @@ async fn get_announcement() {
     // Get the created announcement
     let get_ann = db_handler.get_announcement(original.id).await.unwrap();
 
-    assert_eq!(ProtoAnnouncement::try_from(original).unwrap(), get_ann)
+    assert_eq!(ProtoAnnouncement::from(original), get_ann)
 }
 
 #[tokio::test]
@@ -59,7 +59,6 @@ async fn get_announcements() {
 
     // Create some announcements
     let ann_futures = (0..5)
-        .into_iter()
         .map(|_| async {
             Announcement {
                 id: DieselUlid::generate(),
@@ -90,7 +89,7 @@ async fn get_announcements() {
     assert!(all_announcements.len() >= announcements.len());
 
     for a in &announcements {
-        assert!(all_announcements.contains(&ProtoAnnouncement::try_from(a.clone()).unwrap()))
+        assert!(all_announcements.contains(&ProtoAnnouncement::from(a.clone())))
     }
 
     // Get first, third and last of the created announcements by id
@@ -337,7 +336,7 @@ async fn set_announcements() {
         // Check undeleted
         for id in &ids {
             assert!(
-                Announcement::get(DieselUlid::from_str(&id).unwrap(), &client)
+                Announcement::get(DieselUlid::from_str(id).unwrap(), &client)
                     .await
                     .unwrap()
                     .is_some()
@@ -347,7 +346,7 @@ async fn set_announcements() {
         // Check deleted
         for id in &deleted_ids {
             assert!(
-                Announcement::get(DieselUlid::from_str(&id).unwrap(), &client)
+                Announcement::get(DieselUlid::from_str(id).unwrap(), &client)
                     .await
                     .unwrap()
                     .is_none()

--- a/components/server/tests/middlelayer/announcements.rs
+++ b/components/server/tests/middlelayer/announcements.rs
@@ -1,6 +1,10 @@
-use aruna_rust_api::api::storage::services::v2::Announcement as ProtoAnnouncement;
+use aruna_rust_api::api::storage::{
+    models::v2::PageRequest,
+    services::v2::{Announcement as ProtoAnnouncement, GetAnnouncementsRequest},
+};
 use aruna_server::database::dsls::info_dsl::Announcement;
 use diesel_ulid::DieselUlid;
+use itertools::Itertools;
 
 use crate::common::init::init_database_handler_middlelayer;
 
@@ -36,3 +40,86 @@ async fn get_announcement() {
     assert_eq!(ProtoAnnouncement::try_from(original).unwrap(), get_ann)
 }
 
+#[tokio::test]
+async fn get_announcements() {
+    // Init middleware database handler
+    let db_handler = init_database_handler_middlelayer().await;
+    let client = db_handler.database.get_client().await.unwrap();
+
+    // Create some announcements
+    let ann_futures = (0..5)
+        .into_iter()
+        .map(|_| async {
+            Announcement {
+                id: DieselUlid::generate(),
+                announcement_type: "ORGA".to_string(),
+                title: "Announcement Title".to_string(),
+                teaser: "Announcement Teaser".to_string(),
+                image_url: "https://announcement_image_url/{}.webp".to_string(),
+                content: "Announcement Content {}".to_string(),
+                created_by: "The Aruna Team".to_string(),
+                created_at: chrono::Utc::now().naive_local(),
+                modified_by: "The Aruna Team".to_string(),
+                modified_at: chrono::Utc::now().naive_local(),
+            }
+            .upsert(&client)
+            .await
+            .unwrap()
+        })
+        .collect_vec();
+    let announcements = futures::future::join_all(ann_futures).await;
+
+    let mut request = GetAnnouncementsRequest {
+        announcement_ids: vec![],
+        page: None,
+    };
+
+    // Get all announcements
+    let all_announcements = db_handler.get_announcements(request.clone()).await.unwrap();
+    assert!(all_announcements.len() >= announcements.len());
+
+    for a in &announcements {
+        assert!(all_announcements.contains(&ProtoAnnouncement::try_from(a.clone()).unwrap()))
+    }
+
+    // Get first, third and last of the created announcements by id
+    request.announcement_ids = vec![
+        announcements.first().unwrap().id.to_string(),
+        announcements.get(2).unwrap().id.to_string(),
+        announcements.last().unwrap().id.to_string(),
+    ];
+    let anns = db_handler.get_announcements(request.clone()).await.unwrap();
+    assert_eq!(anns.len(), 3);
+
+    // Get pages with two announcements
+    let mut page = PageRequest {
+        start_after: "".to_string(),
+        page_size: 2,
+    };
+    request.announcement_ids = vec![];
+    request.page = Some(page.clone());
+
+    let page_01 = db_handler.get_announcements(request.clone()).await.unwrap();
+    assert_eq!(page_01.as_slice(), &all_announcements[..2]);
+
+    page.start_after = page_01.last().unwrap().announcement_id.clone();
+    request.page = Some(page);
+    let page_02 = db_handler.get_announcements(request.clone()).await.unwrap();
+    assert_eq!(page_02.as_slice(), &all_announcements[2..4]);
+}
+
+#[tokio::test]
+async fn get_announcements_by_type() {
+    // Init
+    let db_handler = init_database_handler_middlelayer().await;
+
+    todo!()
+}
+
+#[tokio::test]
+async fn set_announcements() {
+    // Init
+    let db_handler = init_database_handler_middlelayer().await;
+
+    todo!()
+}

--- a/components/server/tests/middlelayer/announcements.rs
+++ b/components/server/tests/middlelayer/announcements.rs
@@ -1,0 +1,38 @@
+use aruna_rust_api::api::storage::services::v2::Announcement as ProtoAnnouncement;
+use aruna_server::database::dsls::info_dsl::Announcement;
+use diesel_ulid::DieselUlid;
+
+use crate::common::init::init_database_handler_middlelayer;
+
+#[tokio::test]
+async fn get_announcement() {
+    // Init middleware database handler
+    let db_handler = init_database_handler_middlelayer().await;
+    let client = db_handler.database.get_client().await.unwrap();
+
+    // Create an announcement in the database
+    let original = Announcement {
+        id: DieselUlid::generate(),
+        announcement_type: "RELEASE".to_string(),
+        title: "Announcement Title".to_string(),
+        teaser: "Announcement Teaser".to_string(),
+        image_url: format!("https://announcement_image_url/dummy.webp"),
+        content: "Announcement Content".to_string(),
+        created_by: "The Aruna Team".to_string(),
+        created_at: chrono::Utc::now().naive_local(),
+        modified_by: "The Aruna Team".to_string(),
+        modified_at: chrono::Utc::now().naive_local(),
+    }
+    .upsert(&client)
+    .await
+    .unwrap();
+
+    // Error: get non-existent announcement
+    assert!(db_handler.get_announcement(original.id).await.is_err());
+
+    // Get the created announcement
+    let get_ann = db_handler.get_announcement(original.id).await.unwrap();
+
+    assert_eq!(ProtoAnnouncement::try_from(original).unwrap(), get_ann)
+}
+

--- a/components/server/tests/middlelayer/mod.rs
+++ b/components/server/tests/middlelayer/mod.rs
@@ -1,3 +1,4 @@
+mod announcements;
 mod create;
 mod delete;
 mod endpoints;


### PR DESCRIPTION
This pull request introduces the implementation of the  announcements API part of the StorageStatusServer. The implemented API endpoints allow Aruna administrators to create and manage public announcements, providing a natively integrated capability for handling announcement data. Retrieval is publicly available without the need for authentication which provides an easily accessible way for everyone to display the announcements in other services.

In addition to the API implementation, extensive unit testing is included to ensure the reliability and correctness of the new functionality.

## Changes:

* Update `aruna_rust_api` dependency to version 2.0.0-beta.15.1
* Extends the database schema with the table `announcements`
* Implements the `StorageStatusServer` API endpoints `set_announcements`, `get_announcement`, `get_announcements` and `get_announcements_by_type`
* Add tests for all implemented functions