### PR TITLE
Refactor public announcements

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -1453,12 +1453,13 @@ dependencies = [
 
 [[package]]
 name = "diesel-ulid"
-version = "0.3.1"
+version = "0.3.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "d7b0784f3b493be82010c55a48c9066a05fe3e5fcde76f316c99c12d6cd6f661"
+checksum = "399977436b3a265750eaa2040d46b55612d12bca7717f7784b55d4d42f691f0f"
 dependencies = [
  "bytes",
  "postgres-types",
+ "rand",
  "rusty_ulid",
  "serde",
  "serde_with",
@@ -5049,9 +5050,9 @@ checksum = "daf8dba3b7eb870caf1ddeed7bc9d2a049f3cfdfae7cb521b087cc33ae4c49da"
 
 [[package]]
 name = "uuid"
-version = "1.8.0"
+version = "1.10.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "a183cf7feeba97b4dd1c0d46788634f6221d87fa961b305bed08c851829efcc0"
+checksum = "81dfa00651efa65069b0b6b651f4aaa31ba9e3c3ce0137aaad053604ee7e0314"
 dependencies = [
  "getrandom",
  "rand",
@@ -5061,9 +5062,9 @@ dependencies = [
 
 [[package]]
 name = "uuid-macro-internal"
-version = "1.8.0"
+version = "1.10.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "9881bea7cbe687e36c9ab3b778c36cd0487402e270304e8b1296d5085303c1a2"
+checksum = "ee1cd046f83ea2c4e920d6ee9f7c3537ef928d75dce5d84a87c2c5d6b3999a3a"
 dependencies = [
  "proc-macro2",
  "quote",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -25,7 +25,7 @@ cel-parser = "0.6.0"
 chrono = "0.4.34"
 dashmap = {version = "5.5.3", features = ["serde"]}
 deadpool-postgres = "0.13.0"
-diesel-ulid = "0.3.1"
+diesel-ulid = "0.3.2"
 dotenvy = "0.15.7"
 futures = "0.3.30"
 hex = "0.4.3"

--- a/components/server/src/database/dsls/info_dsl.rs
+++ b/components/server/src/database/dsls/info_dsl.rs
@@ -91,7 +91,7 @@ impl Announcement {
               image_url = EXCLUDED.image_url,
               content = EXCLUDED.content,
               modified_by = $9,
-              modified_at = $10
+              modified_at = (NOW() at time zone 'utc')
             RETURNING *;";
 
         let prepared = client.prepare(query).await?;

--- a/components/server/src/database/dsls/info_dsl.rs
+++ b/components/server/src/database/dsls/info_dsl.rs
@@ -64,7 +64,7 @@ impl CrudDb for Announcement {
     }
 
     async fn all(client: &Client) -> anyhow::Result<Vec<Self>> {
-        let query = "SELECT * FROM announcements ORDER BY created_at;";
+        let query = "SELECT * FROM announcements ORDER BY created_at DESC;";
         let prepared = client.prepare(query).await?;
         let rows = client.query(&prepared, &[]).await?;
         Ok(rows.iter().map(Announcement::from_row).collect::<Vec<_>>())
@@ -128,13 +128,16 @@ impl Announcement {
         let rows = if let Some(page) = page {
             if let Ok(start_after) = DieselUlid::from_str(&page.start_after) {
                 inserts.push(&start_after);
-                query.push_str(&format!("WHERE id > ${} ", inserts.len()));
+                query.push_str(&format!("WHERE id < ${} ", inserts.len()));
 
                 if page.page_size > 0 {
                     inserts.push(&page.page_size);
-                    query.push_str(&format!(" ORDER BY created_at LIMIT ${};", inserts.len()));
+                    query.push_str(&format!(
+                        " ORDER BY created_at DESC LIMIT ${};",
+                        inserts.len()
+                    ));
                 } else {
-                    query.push_str(" ORDER BY created_at;");
+                    query.push_str(" ORDER BY created_at DESC;");
                 }
 
                 let prepared = client.prepare(&query).await?;
@@ -142,16 +145,19 @@ impl Announcement {
             } else {
                 if page.page_size > 0 {
                     inserts.push(&page.page_size);
-                    query.push_str(&format!(" ORDER BY created_at LIMIT ${};", inserts.len()));
+                    query.push_str(&format!(
+                        " ORDER BY created_at DESC LIMIT ${};",
+                        inserts.len()
+                    ));
                 } else {
-                    query.push_str(" ORDER BY created_at;");
+                    query.push_str(" ORDER BY created_at DESC;");
                 }
 
                 let prepared = client.prepare(&query).await?;
                 client.query(&prepared, &inserts).await?
             }
         } else {
-            query.push_str(" ORDER BY created_at;");
+            query.push_str(" ORDER BY created_at DESC;");
             let prepared = client.prepare(&query).await?;
             client.query(&prepared, &inserts).await?
         };
@@ -181,13 +187,16 @@ impl Announcement {
         let rows = if let Some(page) = page {
             if let Ok(start_after) = DieselUlid::from_str(&page.start_after) {
                 inserts.push(&start_after);
-                query.push_str(&format!(" AND id > ${}", inserts.len()));
+                query.push_str(&format!(" AND id < ${}", inserts.len()));
 
                 if page.page_size > 0 {
                     inserts.push(&page.page_size);
-                    query.push_str(&format!(" ORDER BY created_at LIMIT ${};", inserts.len()));
+                    query.push_str(&format!(
+                        " ORDER BY created_at DESC LIMIT ${};",
+                        inserts.len()
+                    ));
                 } else {
-                    query.push_str(" ORDER BY created_at;");
+                    query.push_str(" ORDER BY created_at DESC;");
                 }
 
                 let prepared = client.prepare(&query).await?;
@@ -195,16 +204,19 @@ impl Announcement {
             } else {
                 if page.page_size > 0 {
                     inserts.push(&page.page_size);
-                    query.push_str(&format!(" ORDER BY created_at LIMIT ${};", inserts.len()));
+                    query.push_str(&format!(
+                        " ORDER BY created_at DESC LIMIT ${};",
+                        inserts.len()
+                    ));
                 } else {
-                    query.push_str(" ORDER BY created_at;");
+                    query.push_str(" ORDER BY created_at DESC;");
                 }
 
                 let prepared = client.prepare(&query).await?;
                 client.query(&prepared, &inserts).await?
             }
         } else {
-            query.push_str(" ORDER BY created_at;");
+            query.push_str(" ORDER BY created_at DESC;");
             let prepared = client.prepare(&query).await?;
             client.query(&prepared, &inserts).await?
         };
@@ -241,13 +253,16 @@ impl Announcement {
         let rows = if let Some(page) = page {
             if let Ok(start_after) = DieselUlid::from_str(&page.start_after) {
                 params.push(&start_after);
-                query.push_str(&format!(" AND id > ${}", params.len()));
+                query.push_str(&format!(" AND id < ${}", params.len()));
 
                 if page.page_size > 0 {
                     params.push(&page.page_size);
-                    query.push_str(&format!(" ORDER BY created_at LIMIT ${};", params.len()));
+                    query.push_str(&format!(
+                        " ORDER BY created_at DESC LIMIT ${};",
+                        params.len()
+                    ));
                 } else {
-                    query.push_str(" ORDER BY created_at;");
+                    query.push_str(" ORDER BY created_at DESC;");
                 }
 
                 let prepared = client.prepare(&query).await?;
@@ -255,16 +270,19 @@ impl Announcement {
             } else {
                 if page.page_size > 0 {
                     params.push(&page.page_size);
-                    query.push_str(&format!(" ORDER BY created_at LIMIT ${};", params.len()));
+                    query.push_str(&format!(
+                        " ORDER BY created_at DESC LIMIT ${};",
+                        params.len()
+                    ));
                 } else {
-                    query.push_str(" ORDER BY created_at;");
+                    query.push_str(" ORDER BY created_at DESC;");
                 }
 
                 let prepared = client.prepare(&query).await?;
                 client.query(&prepared, &params).await?
             }
         } else {
-            query.push_str(" ORDER BY created_at;");
+            query.push_str(" ORDER BY created_at DESC;");
             let prepared = client.prepare(&query).await?;
             client.query(&prepared, &params).await?
         };

--- a/components/server/src/utils/grpc_utils.rs
+++ b/components/server/src/utils/grpc_utils.rs
@@ -11,6 +11,7 @@ use aruna_rust_api::api::storage::models::v2::{
     ReplicationStatus, User,
 };
 use base64::{engine::general_purpose, Engine};
+use chrono::{DateTime, NaiveDateTime};
 use diesel_ulid::DieselUlid;
 use rusty_ulid::DecodingError;
 use std::str::FromStr;
@@ -20,6 +21,11 @@ use tonic::{Result, Status};
 use xxhash_rust::xxh3::xxh3_128;
 
 use super::conversions::relations::from_db_internal_relation;
+
+pub fn from_prost_time(prost_stamp: Option<prost_wkt_types::Timestamp>) -> Option<NaiveDateTime> {
+    DateTime::from_timestamp(prost_stamp.as_ref()?.seconds, prost_stamp?.nanos as u32)
+        .map(|e| e.naive_utc())
+}
 
 pub fn type_name_of<T>(_: T) -> &'static str {
     std::any::type_name::<T>()

--- a/components/server/tests/database/announcements.rs
+++ b/components/server/tests/database/announcements.rs
@@ -132,11 +132,10 @@ async fn get_test() {
         page_01_positions
             .iter()
             .zip(&page_02_positions)
-            .filter(|&(a, b)| b > a)
+            .filter(|&(a, b)| a < b)
             .count(),
         2
     );
-    //assert_eq!(page_02.as_slice(), &all[2..4]);
 
     // Get announcements filtered by id
     let ids = announcements
@@ -186,11 +185,11 @@ async fn get_test() {
     assert!(
         all_typed
             .iter()
-            .position(|a| a == get_typed_page_02.first().unwrap())
+            .position(|a| a == get_typed_page_01.first().unwrap())
             .unwrap()
-            > all_typed
+            < all_typed
                 .iter()
-                .position(|a| a == get_typed_page_01.first().unwrap())
+                .position(|a| a == get_typed_page_02.first().unwrap())
                 .unwrap()
     );
 }

--- a/components/server/tests/middlelayer/announcements.rs
+++ b/components/server/tests/middlelayer/announcements.rs
@@ -26,7 +26,7 @@ async fn get_announcement() {
     let original = Announcement {
         id: DieselUlid::generate(),
         announcement_type: "RELEASE".to_string(),
-        title: "Announcement Title".to_string(),
+        title: "middlelayer get_announcement()".to_string(),
         teaser: "Announcement Teaser".to_string(),
         image_url: "https://announcement_image_url/dummy.webp".to_string(),
         content: "Announcement Content".to_string(),
@@ -58,14 +58,15 @@ async fn get_announcements() {
     let client = db_handler.database.get_client().await.unwrap();
 
     // Create some announcements
-    let ann_futures = (0..5)
-        .map(|_| async {
+    let mut announcements = vec![];
+    for idx in 0..5 {
+        announcements.push(
             Announcement {
                 id: DieselUlid::generate(),
                 announcement_type: "ORGA".to_string(),
-                title: "Announcement Title".to_string(),
+                title: format!("middlelayer get_announcements({})", idx),
                 teaser: "Announcement Teaser".to_string(),
-                image_url: "https://announcement_image_url/{}.webp".to_string(),
+                image_url: "https://announcement_image_url/some_dummy.webp".to_string(),
                 content: "Announcement Content {}".to_string(),
                 created_by: "The Aruna Team".to_string(),
                 created_at: chrono::Utc::now().naive_local(),
@@ -74,10 +75,10 @@ async fn get_announcements() {
             }
             .upsert(&client)
             .await
-            .unwrap()
-        })
-        .collect_vec();
-    let announcements = futures::future::join_all(ann_futures).await;
+            .unwrap(),
+        );
+        std::thread::sleep(std::time::Duration::from_millis(10))
+    }
 
     let mut request = GetAnnouncementsRequest {
         announcement_ids: vec![],
@@ -132,7 +133,7 @@ async fn get_announcements() {
         page_01_positions
             .iter()
             .zip(&page_02_positions)
-            .filter(|&(a, b)| b > a)
+            .filter(|&(a, b)| a < b)
             .count(),
         2
     );
@@ -157,7 +158,10 @@ async fn get_announcements_by_type() {
             Announcement {
                 id: DieselUlid::generate(),
                 announcement_type: a_type.to_string(),
-                title: format!("Announcement Title {}", announcements.len() + 1),
+                title: format!(
+                    "middlelayer get_announcements_by_type({})",
+                    announcements.len() + 1
+                ),
                 teaser: format!("Announcement Teaser {}", announcements.len() + 1),
                 image_url: format!(
                     "https://announcement_image_url/{}.webp",
@@ -235,7 +239,7 @@ async fn set_announcements() {
         ProtoAnnouncement {
             announcement_id: "".to_string(),
             announcement_type: AnnouncementType::Release as i32,
-            title: "DbHandler set_announcements dummy 1".to_string(),
+            title: "middlelayer set_announcements(1)".to_string(),
             teaser: "Some teaser".to_string(),
             image_url: "".to_string(),
             content: "Some content".to_string(),
@@ -247,7 +251,7 @@ async fn set_announcements() {
         ProtoAnnouncement {
             announcement_id: "".to_string(),
             announcement_type: AnnouncementType::Blog as i32,
-            title: "DbHandler set_announcements dummy 2".to_string(),
+            title: "middlelayer set_announcements(2)".to_string(),
             teaser: "Some teaser".to_string(),
             image_url: "".to_string(),
             content: "Some content".to_string(),
@@ -259,7 +263,7 @@ async fn set_announcements() {
         ProtoAnnouncement {
             announcement_id: "".to_string(),
             announcement_type: AnnouncementType::Maintenance as i32,
-            title: "DbHandler set_announcements dummy 3".to_string(),
+            title: "middlelayer set_announcements(3)".to_string(),
             teaser: "Some teaser".to_string(),
             image_url: "".to_string(),
             content: "Some content".to_string(),


### PR DESCRIPTION
This refactors parts of the public announcement implementation, especially regarding the creation and fetching of announcements. 

## Changes

* Fetching now always returns the announcements sorted with newest first
* Creation timestamp and the id are now tightly coupled to avoid breaking pagination
* Announcements can be created with a specific timestamp which will be used for the id generation if the id is empty