### PR TITLE
Correct multipart part number handling

### DIFF
--- a/components/server/src/middlelayer/presigned_url_handler.rs
+++ b/components/server/src/middlelayer/presigned_url_handler.rs
@@ -461,7 +461,7 @@ impl PresignedUpload {
         let multipart = self.get_multipart();
         let part_number = self.0.part_number;
         let parts = match (part_number, multipart) {
-            (n, true) if n < 1 || n > 10000 => {
+            (n, true) if !(1..=10000).contains(&n) => {
                 return Err(anyhow!("Invalid part number provided for multipart upload",))
             }
             (n, true) => n,

--- a/components/server/src/middlelayer/presigned_url_handler.rs
+++ b/components/server/src/middlelayer/presigned_url_handler.rs
@@ -461,10 +461,11 @@ impl PresignedUpload {
         let multipart = self.get_multipart();
         let part_number = self.0.part_number;
         let parts = match (part_number, multipart) {
-            (0, true) => return Err(anyhow!("No part number provided for multipart upload",)),
-            (n, true) if n < 1 => n,
+            (n, true) if n < 1 || n > 10000 => {
+                return Err(anyhow!("Invalid part number provided for multipart upload",))
+            }
+            (n, true) => n,
             (_, false) => 1,
-            _ => return Err(anyhow!("Invalid part number")),
         };
         Ok(parts)
     }


### PR DESCRIPTION
This addresses an issue with the handling of multipart part numbers when generating presigned URLs. Previously, part numbers were incorrectly evaluated, leading to errors with valid part numbers. This fix ensures that part numbers are now evaluated and managed accurately.